### PR TITLE
✨ feat: css 색상 정리

### DIFF
--- a/src/app/styles/index.css
+++ b/src/app/styles/index.css
@@ -3,7 +3,8 @@
 
 :root {
   font-family: 'Pretendard', sans-serif;
-  line-height: 1.5;
+  line-height: 1.4;
+  letter-spacing: -0.025em;
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
@@ -13,4 +14,73 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  /* White & Black */
+  --white: #ffffff;
+  --white-50: #ffffff15;
+  --black: #000000;
+
+  /* Brown */
+  --brown-50: #f6f3f0;
+  --brown-100: #e6ded6;
+  --brown-200: #d2c2b3;
+  --brown-300: #b79d86;
+  --brown-400: #947761;
+  --brown-500: #6b4f3a;
+  --brown-600: #5a4231;
+  --brown-700: #4a3527;
+  --brown-800: #38271d;
+  --brown-900: #241812;
+
+  /* Gray */
+  --gray-50: #fafafa;
+  --gray-100: #f5f5f5;
+  --gray-200: #eeeeee;
+  --gray-300: #e0e0e0;
+  --gray-400: #bdbdbd;
+  --gray-500: #9e9e9e;
+  --gray-600: #757575;
+  --gray-700: #616161;
+  --gray-800: #424242;
+  --gray-900: #212121;
+
+  /* Mauve */
+  --mauve-50: #f8f3f5;
+  --mauve-100: #f1e6eb;
+  --mauve-200: #e3cdd6;
+  --mauve-300: #d1a9b8;
+  --mauve-400: #b9879c;
+  --mauve-500: #7a4b5d;
+  --mauve-600: #643c4a;
+  --mauve-700: #4f2f3a;
+  --mauve-800: #3a222a;
+  --mauve-900: #241518;
+
+  /* Typography */
+  --typo-titleB: var(--black);
+  --typo-titleW: var(--white);
+  --typo-contentW: var(--gray-600);
+  --typo-caption: var(--gray-400);
+
+  /* Footer */
+  --footer-background: var(--brown-800);
+  --footer-copyright: var(--gray-400);
+  --footer-context: var(--gray-300);
+  --footer-divider: var(--white-50);
+
+  /* Book */
+  --book-cover: var(--mauve-500);
+  --book-center: var(--mauve-600);
+  --book-centerDeep: var(--mauve-700);
+  --book-page: var(--white);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  margin: 0;
 }


### PR DESCRIPTION
<!--
```
- PR이 승인되면 해당 브랜치 삭제하기
```
-->

# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

<!-- 이슈에 대한 작업이라면 PR과 이슈 연결 -->

- close #2 

### 색상 팔레트를 css로 정리한 이유

- Figma에 정리해둔 색상을 하나하나 RGB나 HEX 코드로 작성하는 것은 가독성과 유지보수성이 떨어진다고 판단
- 프로그래밍 언어처럼 색상을 변수 선언을 하여 사용되는 색상 값을 변수에 저장하고 호출하면 보다 효율적으로 작업을 할 수 있을 것이라 생각함

### 핵심 변화

#### 변경전
- [255,255,255]나 #FFFFFF 같은 RGB, HEX 코드 형식으로 하드코딩

#### 변경 후
- --black: #000000;
--typo-titleB: var(--black);

위와 같이 CSS 색상 값을 하드코딩 대신 변수(--black)으로 정의

# 📋 작업 내용

- 색상 팔레트 정리

# 📷 스크린 샷 (선택 사항)
<img width="870" height="479" alt="image" src="https://github.com/user-attachments/assets/6c5d9341-fa98-440c-b292-06ece84ad047" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
- 타이포그래피 조정으로 가독성 개선 (라인 높이, 자간 최적화)
- 색상 및 타이포그래피 디자인 토큰 확대
- 제목 및 본문의 일관된 마진 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->