### PR TITLE
⚙️ chore: dependabot 설정 추가

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,14 +15,19 @@ updates:
         patterns:
           - 'react'
           - 'react-dom'
+        dependency-type: 'production'
+      react-types:
+        patterns:
           - '@types/react'
           - '@types/react-dom'
+        dependency-type: 'development'
       vite:
         patterns:
           - 'vite'
           - 'rolldown-vite'
           - '@vitejs/*'
           - 'vite-*'
+        dependency-type: 'development'
       eslint:
         patterns:
           - 'eslint'
@@ -30,23 +35,30 @@ updates:
           - '@eslint/*'
           - 'typescript-eslint'
           - 'globals'
+        dependency-type: 'development'
       typescript:
         patterns:
           - 'typescript'
           - '@types/*'
+        dependency-type: 'development'
       prettier:
         patterns:
           - 'prettier'
           - '@trivago/prettier-plugin-sort-imports'
+        dependency-type: 'development'
       commitizen:
         patterns:
           - 'commitizen'
           - 'cz-customizable'
           - '@commitlint/*'
+        dependency-type: 'development'
       husky:
         patterns:
           - 'husky'
           - 'lint-staged'
+        dependency-type: 'development'
+      dev-dependencies:
+        dependency-type: 'development'
     ignore:
       - dependency-name: '*'
         update-types:


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #2

### Dependabot이란?

GitHub에서 공식 제공하는 의존성 자동 업데이트 봇입니다. `.github/dependabot.yml` 설정 파일을 추가하면 활성화되며, 프로젝트에서 사용 중인 패키지의 새 버전이 출시될 때 자동으로 업데이트 PR을 생성합니다. 개발자가 직접 `npm outdated`를 실행하거나 변경 사항을 수동으로 추적하지 않아도 되므로, 보안 패치나 버그 수정이 포함된 최신 버전을 놓치지 않고 관리할 수 있습니다.

### Dependabot 설정 추가

- 의존성 자동 업데이트 자동화를 위해 `.github/dependabot.yml` 설정 파일을 추가함
- PR 관리 비용을 줄이기 위해 관련 패키지를 그룹핑하여 PR 수를 최소화함
- `rolldown-vite@7.x` 오버라이드 정책과 충돌하지 않도록 vite 8+ 업그레이드를 ignore 처리함
- 매주 월요일 오전 9:00 의존성 업데이트 확인
- major 버전 업데이트를 전체 패키지에 대해 ignore 처리하여 breaking change 위험 방지

### Semantic Versioning (semver) 버전 체계

### Patch (x.x.1 → x.x.2)

버그 수정, 보안 패치 등 하위 호환성을 완전히 유지하는 변경. API나 동작 방식이 바뀌지 않으므로 업데이트 시 사이드 이펙트가 없다.

### Minor (x.1.x → x.2.x)

새 기능 추가, 기존 API는 유지한 채 기능을 확장하는 변경. 하위 호환성은 보장되나 새로운 동작이 추가될 수 있어 테스트가 권장된다.

### Major (1.x.x → 2.x.x)

기존 API 제거·변경, 동작 방식 변경 등 breaking change가 포함된 업데이트. 마이그레이션 가이드 없이 적용하면 빌드 오류나 런타임 에러가 발생할 수 있다.

### Minor·Patch만 허용한 이유

Major 업데이트는 breaking change를 동반하므로 Dependabot이 자동으로 PR을 올리더라도 실제 적용 전 반드시 마이그레이션 가이드와 코드 호환성을 수동으로 검토해야 한다. 자동화의 이점을 살리면서도 예기치 못한 빌드·런타임 오류를 방지하기 위해 minor와 patch 업데이트만 Dependabot에 위임하고, major 업데이트는 별도의 검토 프로세스를 거치도록 제한하였다.

### 핵심 변화

#### 변경 전

- 의존성 업데이트를 수동으로 확인하고 처리
- major 버전 포함 모든 업데이트 PR이 생성됨

#### 변경 후

- 매주 월요일 09:00 (Asia/Seoul) 기준으로 Dependabot이 자동으로 업데이트 PR 생성
- 패키지를 7개 그룹으로 묶어 PR 수 최소화: `react`, `vite`, `eslint`, `typescript`, `prettier`, `commitizen`, `husky`
- `version-update:semver-major` ignore로 major 업데이트 PR 생성 차단

# 📋 작업 내용

- `.github/dependabot.yml` 파일 추가
  - `package-ecosystem: npm` 설정
  - 업데이트 주기: 매주 월요일 09:00 (Asia/Seoul)
  - `open-pull-requests-limit: 10`
  - `labels: 🤖 Dependency` 자동 부착
  - 관련 패키지 그룹핑으로 PR 수 최소화
  - `vite >= 7` 버전 ignore (rolldown-vite 오버라이드 유지)
  - 전체 패키지 major 버전 업데이트 ignore

# 📷 스크린 샷 (선택 사항)

해당 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 의존성 업데이트를 자동으로 관리하는 설정이 추가되었습니다. 주간 주기로 예약되어 있으며, 여러 의존성 카테고리에 대한 업데이트 규칙이 포함되어 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->