### PR TITLE
⚙️ chore: develop 브랜치 도입 및 CI 대상 브랜치 전환

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,4 +1,4 @@
-Create a Pull Request from the current branch to `Induel-E-H/web-FE:main`.
+Create a Pull Request from the current branch to `Induel-E-H/web-FE:develop`.
 
 > Upstream repository: https://github.com/Induel-E-H/web-FE
 
@@ -10,8 +10,8 @@ Run these commands:
 
 ```bash
 git branch --show-current
-git log upstream/main..HEAD --oneline
-git diff upstream/main..HEAD --stat
+git log upstream/develop..HEAD --oneline
+git diff upstream/develop..HEAD --stat
 gh issue list -R Induel-E-H/web-FE --state open --json number,title,labels --limit 50
 ```
 
@@ -53,7 +53,7 @@ BRANCH=$(git branch --show-current)
 GH_USER=$(gh api user --jq '.login')
 gh pr create \
   --repo Induel-E-H/web-FE \
-  --base main \
+  --base develop \
   --head $GH_USER:$BRANCH \
   --title "[PREFIX] [concise title]" \
   --label "[selected label]" \

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
+    target-branch: 'develop'
     schedule:
       interval: 'weekly'
       day: 'monday'

--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -10,10 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify PR source is develop
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [ "${{ github.head_ref }}" != "develop" ]; then
+          if [ "$HEAD_REF" != "develop" ]; then
             echo "❌ main 브랜치는 develop 브랜치에서의 PR만 허용합니다."
-            echo "현재 소스 브랜치: ${{ github.head_ref }}"
+            echo "현재 소스 브랜치: $HEAD_REF"
             exit 1
           fi
           echo "✅ develop → main PR 확인 완료"

--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -1,0 +1,19 @@
+name: Branch Guard
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source-branch:
+    name: develop → main 브랜치 검증
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR source is develop
+        run: |
+          if [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "❌ main 브랜치는 develop 브랜치에서의 PR만 허용합니다."
+            echo "현재 소스 브랜치: ${{ github.head_ref }}"
+            exit 1
+          fi
+          echo "✅ develop → main PR 확인 완료"

--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -2,7 +2,7 @@ name: Component Test
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,7 +2,7 @@ name: Lighthouse CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

해당 없음

### develop 브랜치 도입 배경

Netlify 무료 플랜의 월 300 빌드 토큰 한도 문제로 `develop` 브랜치를 도입했습니다.

- 배포 1회당 15 토큰 소모 → 한 달에 최대 20회 배포 가능
- 웹사이트 접속 자체도 토큰을 소모하기 때문에 실질적으로 **월 최대 10회 PR 병합**이 안전
- 기능 브랜치들을 `develop`에 먼저 병합해 변경 사항을 모은 뒤, `main`으로 한 번에 병합하여 빌드 횟수를 절약

또한 `develop` 브랜치를 경유하면 **QA 절차를 수행하기에 용이**해, 운영 환경에 버그가 직접 노출되는 것을 방지할 수 있습니다.

### 핵심 변화

#### 변경 전

- CI(Lighthouse, Component Test)가 `main` 대상 PR에서만 동작
- dependabot이 `main` 브랜치로 직접 의존성 업데이트 PR 생성
- `/pr` 커맨드가 `main`을 베이스로 PR 생성
- main 브랜치는 반드시 PR 승인을 거친 후 병합
- PR 승인은 QA 통과 후에 승인
- main 브랜치로의 PR 작성 가능

#### 변경 후

- CI(Lighthouse, Component Test)가 `develop` 대상 PR에서 동작
- dependabot이 `develop` 브랜치로 의존성 업데이트 PR 생성
- `/pr` 커맨드가 `develop`을 베이스로 PR 생성
- `develop` 에서만 `main`으로의 PR 작성 가능

# 📋 작업 내용

- `.github/workflows/component-test.yml` — trigger 브랜치를 `main` → `develop` 으로 변경
- `.github/workflows/lighthouse.yml` — trigger 브랜치를 `main` → `develop` 으로 변경
- `.github/dependabot.yml` — `target-branch: develop` 추가
- `.claude/commands/pr.md` — PR 베이스 브랜치 및 비교 기준을 `develop` 으로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발 워크플로우 구성이 업데이트되었습니다. 풀 리퀘스트 및 자동화된 의존성 업데이트가 이제 `develop` 브랜치를 기본 대상으로 합니다.
  * 주요 브랜치 보호 정책이 추가되어 개발 프로세스의 안정성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->