### PR TITLE
✅ test: Vision 테스트 작성

### DIFF
--- a/src/widgets/vision/model/VisionData.test.ts
+++ b/src/widgets/vision/model/VisionData.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { VISION_DATA } from './VisionData';
+
+describe('VISION_DATA', () => {
+  describe('구조', () => {
+    it('3개의 항목을 포함한다', () => {
+      expect(VISION_DATA).toHaveLength(3);
+    });
+
+    it('각 항목은 title, description, keyword, image 필드를 가진다', () => {
+      VISION_DATA.forEach((item) => {
+        expect(item).toHaveProperty('title');
+        expect(item).toHaveProperty('description');
+        expect(item).toHaveProperty('keyword');
+        expect(item).toHaveProperty('image');
+      });
+    });
+
+    it('모든 항목의 description이 빈 문자열이 아니다', () => {
+      VISION_DATA.forEach((item) => {
+        expect(item.description.trim()).not.toBe('');
+      });
+    });
+  });
+
+  describe('항목 값', () => {
+    it('첫 번째 항목은 Parametric Design이다', () => {
+      expect(VISION_DATA[0].title).toBe('Parametric Design');
+      expect(VISION_DATA[0].keyword).toBe('Param');
+      expect(VISION_DATA[0].image).toBe('vision_param.webp');
+    });
+
+    it('두 번째 항목은 Urban Sculpting이다', () => {
+      expect(VISION_DATA[1].title).toBe('Urban Sculpting');
+      expect(VISION_DATA[1].keyword).toBe('Sculpt');
+      expect(VISION_DATA[1].image).toBe('vision_sculpt.webp');
+    });
+
+    it('세 번째 항목은 Engineering Investment이다', () => {
+      expect(VISION_DATA[2].title).toBe('Engineering Investment');
+      expect(VISION_DATA[2].keyword).toBe('Invest');
+      expect(VISION_DATA[2].image).toBe('vision_invest.webp');
+    });
+  });
+});

--- a/src/widgets/vision/ui/ScrollFadeIn.test.tsx
+++ b/src/widgets/vision/ui/ScrollFadeIn.test.tsx
@@ -31,7 +31,7 @@ describe('useScrollFadeIn', () => {
     };
     const observed = observedElements;
 
-    global.IntersectionObserver = class MockIntersectionObserver {
+    globalThis.IntersectionObserver = class MockIntersectionObserver {
       constructor(
         callback: IntersectionObserverCallback,
         options?: IntersectionObserverInit,

--- a/src/widgets/vision/ui/ScrollFadeIn.test.tsx
+++ b/src/widgets/vision/ui/ScrollFadeIn.test.tsx
@@ -1,0 +1,141 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useScrollFadeIn } from './ScrollFadeIn';
+
+function TestComponent() {
+  useScrollFadeIn();
+  return (
+    <>
+      <div className='fade-section'>section 1</div>
+      <div className='fade-section'>section 2</div>
+    </>
+  );
+}
+
+describe('useScrollFadeIn', () => {
+  let capturedCallback: IntersectionObserverCallback;
+  let observedElements: Element[];
+  const mockDisconnect = vi.fn();
+  const constructorSpy = vi.fn();
+
+  beforeEach(() => {
+    observedElements = [];
+    mockDisconnect.mockClear();
+    constructorSpy.mockClear();
+
+    const disconnect = mockDisconnect;
+    const spy = constructorSpy;
+    const captured = (cb: IntersectionObserverCallback) => {
+      capturedCallback = cb;
+    };
+    const observed = observedElements;
+
+    global.IntersectionObserver = class MockIntersectionObserver {
+      constructor(
+        callback: IntersectionObserverCallback,
+        options?: IntersectionObserverInit,
+      ) {
+        spy(callback, options);
+        captured(callback);
+      }
+      observe(el: Element) {
+        observed.push(el);
+      }
+      disconnect = disconnect;
+      unobserve = vi.fn();
+    } as unknown as typeof IntersectionObserver;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('초기화', () => {
+    it('모든 .fade-section 요소를 observe한다', () => {
+      render(<TestComponent />);
+      expect(observedElements).toHaveLength(2);
+    });
+
+    it('threshold 0.3으로 IntersectionObserver를 생성한다', () => {
+      render(<TestComponent />);
+      expect(constructorSpy).toHaveBeenCalledWith(expect.any(Function), {
+        threshold: 0.3,
+      });
+    });
+  });
+
+  describe('교차 감지', () => {
+    it('isIntersecting=true일 때 해당 요소에 show 클래스를 추가한다', () => {
+      const { container } = render(<TestComponent />);
+      const fadeSections = container.querySelectorAll('.fade-section');
+
+      act(() => {
+        capturedCallback(
+          [
+            {
+              isIntersecting: true,
+              target: fadeSections[0],
+            } as IntersectionObserverEntry,
+          ],
+          {} as IntersectionObserver,
+        );
+      });
+
+      expect(fadeSections[0]).toHaveClass('show');
+    });
+
+    it('isIntersecting=false일 때 show 클래스를 추가하지 않는다', () => {
+      const { container } = render(<TestComponent />);
+      const fadeSections = container.querySelectorAll('.fade-section');
+
+      act(() => {
+        capturedCallback(
+          [
+            {
+              isIntersecting: false,
+              target: fadeSections[0],
+            } as IntersectionObserverEntry,
+          ],
+          {} as IntersectionObserver,
+        );
+      });
+
+      expect(fadeSections[0]).not.toHaveClass('show');
+    });
+
+    it('여러 entry 중 isIntersecting=true인 요소만 show 클래스를 가진다', () => {
+      const { container } = render(<TestComponent />);
+      const fadeSections = container.querySelectorAll('.fade-section');
+
+      act(() => {
+        capturedCallback(
+          [
+            {
+              isIntersecting: true,
+              target: fadeSections[0],
+            } as IntersectionObserverEntry,
+            {
+              isIntersecting: false,
+              target: fadeSections[1],
+            } as IntersectionObserverEntry,
+          ],
+          {} as IntersectionObserver,
+        );
+      });
+
+      expect(fadeSections[0]).toHaveClass('show');
+      expect(fadeSections[1]).not.toHaveClass('show');
+    });
+  });
+
+  describe('클린업', () => {
+    it('언마운트 시 observer.disconnect가 호출된다', () => {
+      const { unmount } = render(<TestComponent />);
+
+      unmount();
+
+      expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/widgets/vision/ui/SectionLayout.test.tsx
+++ b/src/widgets/vision/ui/SectionLayout.test.tsx
@@ -1,0 +1,122 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { SectionLayout } from './SectionLayout';
+
+describe('SectionLayout', () => {
+  describe('기본 렌더링', () => {
+    it('section 요소로 렌더링된다', () => {
+      const { container } = render(
+        <SectionLayout
+          content={<div>content</div>}
+          keyword={<h1>keyword</h1>}
+        />,
+      );
+      expect(container.querySelector('section')).toBeInTheDocument();
+    });
+
+    it('vision__section 클래스를 가진다', () => {
+      const { container } = render(
+        <SectionLayout
+          content={<div>content</div>}
+          keyword={<h1>keyword</h1>}
+        />,
+      );
+      expect(container.querySelector('section')).toHaveClass('vision__section');
+    });
+
+    it('reverse 기본값은 false로 vision__section-reverse 클래스가 없다', () => {
+      const { container } = render(
+        <SectionLayout
+          content={<div>content</div>}
+          keyword={<h1>keyword</h1>}
+        />,
+      );
+      expect(container.querySelector('section')).not.toHaveClass(
+        'vision__section-reverse',
+      );
+    });
+
+    it('content 노드가 vision__content-group 안에 렌더링된다', () => {
+      const { container } = render(
+        <SectionLayout
+          content={<span>my content</span>}
+          keyword={<h1>keyword</h1>}
+        />,
+      );
+      const contentGroup = container.querySelector('.vision__content-group');
+      expect(contentGroup).toBeInTheDocument();
+      expect(contentGroup).toHaveTextContent('my content');
+    });
+
+    it('keyword 노드가 vision__keyword-group 안에 렌더링된다', () => {
+      const { container } = render(
+        <SectionLayout
+          content={<div>content</div>}
+          keyword={<span>my keyword</span>}
+        />,
+      );
+      const keywordGroup = container.querySelector('.vision__keyword-group');
+      expect(keywordGroup).toBeInTheDocument();
+      expect(keywordGroup).toHaveTextContent('my keyword');
+    });
+
+    it('content-group과 keyword-group 모두 fade-section 클래스를 가진다', () => {
+      const { container } = render(
+        <SectionLayout
+          content={<div>content</div>}
+          keyword={<h1>keyword</h1>}
+        />,
+      );
+      expect(container.querySelectorAll('.fade-section')).toHaveLength(2);
+    });
+  });
+
+  describe('reverse prop', () => {
+    it('reverse=true이면 vision__section-reverse 클래스가 추가된다', () => {
+      const { container } = render(
+        <SectionLayout
+          reverse={true}
+          content={<div>content</div>}
+          keyword={<h1>keyword</h1>}
+        />,
+      );
+      expect(container.querySelector('section')).toHaveClass(
+        'vision__section-reverse',
+      );
+    });
+
+    it('reverse=false이면 vision__section-reverse 클래스가 없다', () => {
+      const { container } = render(
+        <SectionLayout
+          reverse={false}
+          content={<div>content</div>}
+          keyword={<h1>keyword</h1>}
+        />,
+      );
+      expect(container.querySelector('section')).not.toHaveClass(
+        'vision__section-reverse',
+      );
+    });
+  });
+
+  describe('React Compiler 메모이제이션 캐시 히트', () => {
+    it('재렌더링 시에도 동일한 UI가 유지된다 (캐시 히트 분기 커버)', () => {
+      const { rerender, container } = render(
+        <SectionLayout
+          content={<div>content</div>}
+          keyword={<h1>keyword</h1>}
+        />,
+      );
+
+      rerender(
+        <SectionLayout
+          content={<div>content</div>}
+          keyword={<h1>keyword</h1>}
+        />,
+      );
+
+      expect(container.querySelector('section')).toHaveClass('vision__section');
+    });
+  });
+});

--- a/src/widgets/vision/ui/Vision.test.tsx
+++ b/src/widgets/vision/ui/Vision.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Vision } from './Vision';
+
+vi.mock('./ScrollFadeIn', () => ({
+  useScrollFadeIn: vi.fn(),
+}));
+
+vi.mock('@widgets/vision/assets/vision_param.webp', () => ({
+  default: 'vision_param.webp',
+}));
+vi.mock('@widgets/vision/assets/vision_sculpt.webp', () => ({
+  default: 'vision_sculpt.webp',
+}));
+vi.mock('@widgets/vision/assets/vision_invest.webp', () => ({
+  default: 'vision_invest.webp',
+}));
+
+describe('Vision', () => {
+  describe('시맨틱 구조', () => {
+    it('VISION_DATA 수(3)만큼 section.vision이 렌더링된다', () => {
+      const { container } = render(<Vision />);
+      expect(container.querySelectorAll('section.vision')).toHaveLength(3);
+    });
+  });
+
+  describe('콘텐츠 렌더링', () => {
+    it('모든 비전 타이틀이 렌더링된다', () => {
+      render(<Vision />);
+      expect(screen.getByText('Parametric Design')).toBeInTheDocument();
+      expect(screen.getByText('Urban Sculpting')).toBeInTheDocument();
+      expect(screen.getByText('Engineering Investment')).toBeInTheDocument();
+    });
+
+    it('모든 키워드가 렌더링된다', () => {
+      render(<Vision />);
+      expect(screen.getByText('Param')).toBeInTheDocument();
+      expect(screen.getByText('Sculpt')).toBeInTheDocument();
+      expect(screen.getByText('Invest')).toBeInTheDocument();
+    });
+
+    it('각 이미지가 title을 alt로 렌더링된다', () => {
+      render(<Vision />);
+      expect(screen.getByAltText('Parametric Design')).toBeInTheDocument();
+      expect(screen.getByAltText('Urban Sculpting')).toBeInTheDocument();
+      expect(screen.getByAltText('Engineering Investment')).toBeInTheDocument();
+    });
+  });
+
+  describe('이미지 매핑', () => {
+    it('Parametric Design 이미지가 vision_param.webp에 매핑된다', () => {
+      render(<Vision />);
+      expect(screen.getByAltText('Parametric Design')).toHaveAttribute(
+        'src',
+        'vision_param.webp',
+      );
+    });
+
+    it('Urban Sculpting 이미지가 vision_sculpt.webp에 매핑된다', () => {
+      render(<Vision />);
+      expect(screen.getByAltText('Urban Sculpting')).toHaveAttribute(
+        'src',
+        'vision_sculpt.webp',
+      );
+    });
+
+    it('Engineering Investment 이미지가 vision_invest.webp에 매핑된다', () => {
+      render(<Vision />);
+      expect(screen.getByAltText('Engineering Investment')).toHaveAttribute(
+        'src',
+        'vision_invest.webp',
+      );
+    });
+  });
+
+  describe('reverse 레이아웃', () => {
+    it('홀수 인덱스(index=1, Urban Sculpting)는 vision__section-reverse 클래스를 가진다', () => {
+      const { container } = render(<Vision />);
+      const innerSections = container.querySelectorAll(
+        'section.vision__section',
+      );
+      expect(innerSections[1]).toHaveClass('vision__section-reverse');
+    });
+
+    it('짝수 인덱스(index=0, Parametric Design)는 reverse 클래스가 없다', () => {
+      const { container } = render(<Vision />);
+      const innerSections = container.querySelectorAll(
+        'section.vision__section',
+      );
+      expect(innerSections[0]).not.toHaveClass('vision__section-reverse');
+    });
+
+    it('짝수 인덱스(index=2, Engineering Investment)는 reverse 클래스가 없다', () => {
+      const { container } = render(<Vision />);
+      const innerSections = container.querySelectorAll(
+        'section.vision__section',
+      );
+      expect(innerSections[2]).not.toHaveClass('vision__section-reverse');
+    });
+  });
+
+  describe('React Compiler 메모이제이션 캐시 히트', () => {
+    it('재렌더링 시에도 동일한 UI가 유지된다 (캐시 히트 분기 커버)', () => {
+      const { rerender } = render(<Vision />);
+
+      rerender(<Vision />);
+
+      expect(screen.getByText('Parametric Design')).toBeInTheDocument();
+      expect(screen.getByText('Urban Sculpting')).toBeInTheDocument();
+      expect(screen.getByText('Engineering Investment')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/widgets/vision/ui/VisionItem.test.tsx
+++ b/src/widgets/vision/ui/VisionItem.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { VisionItem } from './VisionItem';
+
+const defaultProps = {
+  title: 'Parametric Design',
+  description:
+    '수치 기반 설계와 알고리즘 모델링을 통해 최적화된 익스테리어 솔루션을 제공합니다.',
+  keyword: 'Param',
+  image: 'vision_param.webp',
+};
+
+describe('VisionItem', () => {
+  describe('렌더링', () => {
+    it('title이 h2 요소로 렌더링된다', () => {
+      render(<VisionItem {...defaultProps} />);
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+        'Parametric Design',
+      );
+    });
+
+    it('h2에 vision__title 클래스가 있다', () => {
+      const { container } = render(<VisionItem {...defaultProps} />);
+      expect(container.querySelector('h2.vision__title')).toBeInTheDocument();
+    });
+
+    it('description이 vision__description span으로 렌더링된다', () => {
+      const { container } = render(<VisionItem {...defaultProps} />);
+      const span = container.querySelector('.vision__description');
+      expect(span).toBeInTheDocument();
+      expect(span).toHaveTextContent(defaultProps.description);
+    });
+
+    it('keyword가 h1 요소로 렌더링된다', () => {
+      render(<VisionItem {...defaultProps} />);
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'Param',
+      );
+    });
+
+    it('h1에 vision__keyword 클래스가 있다', () => {
+      const { container } = render(<VisionItem {...defaultProps} />);
+      expect(container.querySelector('h1.vision__keyword')).toBeInTheDocument();
+    });
+
+    it('이미지가 title을 alt로 렌더링된다', () => {
+      render(<VisionItem {...defaultProps} />);
+      expect(screen.getByAltText('Parametric Design')).toBeInTheDocument();
+    });
+
+    it('이미지 src에 image prop이 반영된다', () => {
+      render(<VisionItem {...defaultProps} />);
+      expect(screen.getByAltText('Parametric Design')).toHaveAttribute(
+        'src',
+        'vision_param.webp',
+      );
+    });
+  });
+
+  describe('reverse prop', () => {
+    it('reverse 기본값은 false로 vision__section-reverse 클래스가 없다', () => {
+      const { container } = render(<VisionItem {...defaultProps} />);
+      expect(
+        container.querySelector('.vision__section-reverse'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('reverse=true이면 vision__section-reverse 클래스가 적용된다', () => {
+      const { container } = render(
+        <VisionItem {...defaultProps} reverse={true} />,
+      );
+      expect(
+        container.querySelector('.vision__section-reverse'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('React Compiler 메모이제이션 캐시 히트', () => {
+    it('재렌더링 시에도 동일한 UI가 유지된다 (캐시 히트 분기 커버)', () => {
+      const { rerender } = render(<VisionItem {...defaultProps} />);
+
+      rerender(<VisionItem {...defaultProps} />);
+
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+        'Parametric Design',
+      );
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'Param',
+      );
+    });
+  });
+});


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #49

### Vision 테스트 작성

- Vision 위젯의 데이터 모델 및 UI 컴포넌트 전체에 대한 테스트 코드를 작성하였습니다.
- 스크롤 애니메이션, 섹션 레이아웃, 비전 아이템 렌더링 등을 검증합니다.

### 핵심 변화

#### 변경 전

- Vision 관련 테스트 코드 없음

#### 변경 후

- 5개 테스트 파일, 총 516줄 추가

# 📋 작업 내용

- `src/widgets/vision/model/VisionData.test.ts` — Vision 데이터 모델 테스트
- `src/widgets/vision/ui/ScrollFadeIn.test.tsx` — 스크롤 페이드인 애니메이션 컴포넌트 테스트
- `src/widgets/vision/ui/SectionLayout.test.tsx` — 섹션 레이아웃 컴포넌트 테스트
- `src/widgets/vision/ui/Vision.test.tsx` — Vision 위젯 테스트
- `src/widgets/vision/ui/VisionItem.test.tsx` — VisionItem 컴포넌트 테스트

# 🐛 빌드 오류 수정

### 오류

```
Error: src/widgets/vision/ui/ScrollFadeIn.test.tsx(34,5): error TS2304: Cannot find name 'global'.
```

### 원인

`tsconfig.app.json`의 `"include": ["src"]` 설정으로 인해 `tsc -b` 실행 시 테스트 파일도 타입 체크 대상에 포함됩니다.  
브라우저 환경에서는 Node.js의 `global` 객체가 존재하지 않아 TypeScript가 이름을 찾지 못하고 오류를 발생시킵니다.

### 해결

`global` → `globalThis` 로 변경하였습니다.  
`globalThis`는 브라우저·Node.js 양쪽에서 모두 동작하는 표준 전역 객체 참조입니다.

```diff
- global.IntersectionObserver = class MockIntersectionObserver {
+ globalThis.IntersectionObserver = class MockIntersectionObserver {
```

# 📷 스크린 샷 (선택 사항)

동작 화면 첨부