### PR TITLE
✅ test: Map 테스트 작성

### DIFF
--- a/src/widgets/map/model/map.test.ts
+++ b/src/widgets/map/model/map.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeMap } from './map';
+
+const mockMakeMapMarker = vi.hoisted(() => vi.fn());
+const mockUpdateMarkerIcon = vi.hoisted(() => vi.fn());
+const mockMakeInfoCard = vi.hoisted(() => vi.fn());
+
+vi.mock('./mapMarker', () => ({
+  makeMapMarker: mockMakeMapMarker,
+  updateMarkerIcon: mockUpdateMarkerIcon,
+}));
+vi.mock('./mapInfoCard', () => ({
+  makeInfoCard: mockMakeInfoCard,
+}));
+
+describe('map', () => {
+  const mockMapObj = { getCenter: vi.fn() };
+  const mockMarker = {};
+  const mockGetMap = vi.fn();
+  const mockClose = vi.fn();
+  const mockOpenIW = vi.fn();
+  const mockInfoWindow = {
+    getMap: mockGetMap,
+    close: mockClose,
+    open: mockOpenIW,
+  };
+
+  const MockNaverMap = vi.fn().mockImplementation(function () {
+    return mockMapObj;
+  });
+  const MockLatLng = vi.fn().mockImplementation(function (
+    lat: number,
+    lng: number,
+  ) {
+    return { lat, lng };
+  });
+
+  let mockEl: HTMLDivElement;
+  let lastCleanup: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEl = document.createElement('div');
+    mockMakeMapMarker.mockReturnValue(mockMarker);
+    mockMakeInfoCard.mockReturnValue(mockInfoWindow);
+    mockGetMap.mockReturnValue(null);
+
+    vi.stubGlobal('naver', {
+      maps: {
+        Map: MockNaverMap,
+        LatLng: MockLatLng,
+        Position: { TOP_RIGHT: 'TOP_RIGHT' },
+      },
+    });
+
+    // 기본 screen/devicePixelRatio (physicalWidth = 1920)
+    vi.stubGlobal('screen', { width: 1920 });
+    vi.stubGlobal('devicePixelRatio', 1);
+  });
+
+  afterEach(() => {
+    lastCleanup?.();
+    lastCleanup = undefined;
+    vi.unstubAllGlobals();
+  });
+
+  describe('getZoom (makeMap을 통해 간접 검증)', () => {
+    it('physicalWidth < 3840이면 zoom 15로 지도가 생성된다', () => {
+      vi.stubGlobal('screen', { width: 1920 });
+      vi.stubGlobal('devicePixelRatio', 1); // 1920 * 1 = 1920
+
+      lastCleanup = makeMap(mockEl);
+
+      expect(MockNaverMap).toHaveBeenCalledWith(
+        mockEl,
+        expect.objectContaining({ zoom: 15 }),
+      );
+    });
+
+    it('physicalWidth === 3840이면 zoom 17로 지도가 생성된다', () => {
+      vi.stubGlobal('screen', { width: 3840 });
+      vi.stubGlobal('devicePixelRatio', 1); // 3840 * 1 = 3840
+
+      lastCleanup = makeMap(mockEl);
+
+      expect(MockNaverMap).toHaveBeenCalledWith(
+        mockEl,
+        expect.objectContaining({ zoom: 17 }),
+      );
+    });
+
+    it('physicalWidth === 7680이면 zoom 20으로 지도가 생성된다', () => {
+      vi.stubGlobal('screen', { width: 7680 });
+      vi.stubGlobal('devicePixelRatio', 1); // 7680 * 1 = 7680
+
+      lastCleanup = makeMap(mockEl);
+
+      expect(MockNaverMap).toHaveBeenCalledWith(
+        mockEl,
+        expect.objectContaining({ zoom: 20 }),
+      );
+    });
+  });
+
+  describe('makeMap', () => {
+    it('center로 LatLng(35.13488, 129.0968)를 사용한다', () => {
+      lastCleanup = makeMap(mockEl);
+
+      expect(MockLatLng).toHaveBeenCalledWith(35.13488, 129.0968);
+    });
+
+    it('zoomControl이 활성화된다', () => {
+      lastCleanup = makeMap(mockEl);
+
+      expect(MockNaverMap).toHaveBeenCalledWith(
+        mockEl,
+        expect.objectContaining({ zoomControl: true }),
+      );
+    });
+
+    it('makeMapMarker가 생성된 지도로 호출된다', () => {
+      lastCleanup = makeMap(mockEl);
+
+      expect(mockMakeMapMarker).toHaveBeenCalledWith(mockMapObj);
+    });
+
+    it('makeInfoCard가 지도와 마커로 호출된다', () => {
+      lastCleanup = makeMap(mockEl);
+
+      expect(mockMakeInfoCard).toHaveBeenCalledWith(mockMapObj, mockMarker);
+    });
+
+    it('window에 resize 이벤트 리스너가 등록된다', () => {
+      const addSpy = vi.spyOn(window, 'addEventListener');
+
+      lastCleanup = makeMap(mockEl);
+
+      expect(addSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+    });
+
+    it('반환된 cleanup 함수 호출 시 resize 리스너가 제거된다', () => {
+      const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+      const cleanup = makeMap(mockEl);
+      cleanup();
+
+      expect(removeSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+    });
+  });
+
+  describe('onResize 핸들러', () => {
+    it('InfoWindow가 닫혀있을 때 resize → updateMarkerIcon만 호출된다', () => {
+      mockGetMap.mockReturnValue(null);
+      lastCleanup = makeMap(mockEl);
+
+      window.dispatchEvent(new Event('resize'));
+
+      expect(mockUpdateMarkerIcon).toHaveBeenCalledWith(mockMarker);
+      expect(mockClose).not.toHaveBeenCalled();
+      expect(mockOpenIW).not.toHaveBeenCalled();
+    });
+
+    it('InfoWindow가 열려있을 때 resize → close 후 재오픈된다', () => {
+      mockGetMap.mockReturnValue({} /* truthy */);
+      lastCleanup = makeMap(mockEl);
+
+      window.dispatchEvent(new Event('resize'));
+
+      expect(mockUpdateMarkerIcon).toHaveBeenCalledWith(mockMarker);
+      expect(mockClose).toHaveBeenCalledOnce();
+      expect(mockOpenIW).toHaveBeenCalledWith(mockMapObj, mockMarker);
+    });
+  });
+});

--- a/src/widgets/map/model/mapInfoCard.test.ts
+++ b/src/widgets/map/model/mapInfoCard.test.ts
@@ -1,0 +1,129 @@
+import { COMPANY } from '@shared/constant';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeInfoCard } from './mapInfoCard';
+
+vi.mock('@assets/induel-icon.svg?raw', () => ({
+  default: '<svg viewBox="0 0 649 748"><g /></svg>',
+}));
+
+describe('mapInfoCard', () => {
+  const mockGetMap = vi.fn();
+  const mockClose = vi.fn();
+  const mockOpen = vi.fn();
+  const mockInfoWindow = {
+    getMap: mockGetMap,
+    close: mockClose,
+    open: mockOpen,
+  };
+
+  let capturedClickHandler: (() => void) | null = null;
+
+  const MockInfoWindow = vi.fn().mockImplementation(function () {
+    return mockInfoWindow;
+  });
+  const MockAddListener = vi
+    .fn()
+    .mockImplementation(
+      (_marker: unknown, _event: string, handler: () => void) => {
+        capturedClickHandler = handler;
+      },
+    );
+
+  const mockMap = {} as naver.maps.Map;
+  const mockMarker = {} as naver.maps.Marker;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedClickHandler = null;
+    vi.stubGlobal('naver', {
+      maps: {
+        InfoWindow: MockInfoWindow,
+        Event: { addListener: MockAddListener },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('makeInfoCard', () => {
+    it('InfoWindow를 생성하고 반환한다', () => {
+      const result = makeInfoCard(mockMap, mockMarker);
+
+      expect(MockInfoWindow).toHaveBeenCalledOnce();
+      expect(result).toBe(mockInfoWindow);
+    });
+
+    it('InfoWindow content에 회사 한글 이름이 포함된다', () => {
+      makeInfoCard(mockMap, mockMarker);
+
+      const content = MockInfoWindow.mock.calls[0][0].content as string;
+      expect(content).toContain(COMPANY.NAME_KO);
+    });
+
+    it('InfoWindow content에 회사 영문 약칭이 포함된다', () => {
+      makeInfoCard(mockMap, mockMarker);
+
+      const content = MockInfoWindow.mock.calls[0][0].content as string;
+      expect(content).toContain(COMPANY.NAME_EN);
+    });
+
+    it('InfoWindow content에 전화번호 tel: 링크가 포함된다', () => {
+      makeInfoCard(mockMap, mockMarker);
+
+      const content = MockInfoWindow.mock.calls[0][0].content as string;
+      expect(content).toContain(`tel:${COMPANY.PHONE}`);
+      expect(content).toContain(COMPANY.PHONE_DISPLAY);
+    });
+
+    it('InfoWindow content에 회사 주소가 포함된다', () => {
+      makeInfoCard(mockMap, mockMarker);
+
+      const content = MockInfoWindow.mock.calls[0][0].content as string;
+      expect(content).toContain(COMPANY.ADDRESS_FULL);
+      expect(content).toContain(COMPANY.ADDRESS_SUB);
+    });
+
+    it('마커에 click 이벤트 리스너가 등록된다', () => {
+      makeInfoCard(mockMap, mockMarker);
+
+      expect(MockAddListener).toHaveBeenCalledWith(
+        mockMarker,
+        'click',
+        expect.any(Function),
+      );
+    });
+
+    it('InfoWindow에 borderWidth: 0이 설정된다', () => {
+      makeInfoCard(mockMap, mockMarker);
+
+      expect(MockInfoWindow).toHaveBeenCalledWith(
+        expect.objectContaining({ borderWidth: 0 }),
+      );
+    });
+  });
+
+  describe('click 핸들러 토글', () => {
+    it('InfoWindow가 열려있을 때 클릭하면 닫힌다', () => {
+      mockGetMap.mockReturnValue({} /* truthy — 열려있음 */);
+      makeInfoCard(mockMap, mockMarker);
+
+      capturedClickHandler!();
+
+      expect(mockClose).toHaveBeenCalledOnce();
+      expect(mockOpen).not.toHaveBeenCalled();
+    });
+
+    it('InfoWindow가 닫혀있을 때 클릭하면 열린다', () => {
+      mockGetMap.mockReturnValue(null /* falsy — 닫혀있음 */);
+      makeInfoCard(mockMap, mockMarker);
+
+      capturedClickHandler!();
+
+      expect(mockOpen).toHaveBeenCalledWith(mockMap, mockMarker);
+      expect(mockClose).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/widgets/map/model/mapMarker.test.ts
+++ b/src/widgets/map/model/mapMarker.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeMapMarker, updateMarkerIcon } from './mapMarker';
+
+vi.mock('@assets/induel-icon.svg?raw', () => ({
+  default: '<svg viewBox="0 0 649 748"><g /></svg>',
+}));
+
+describe('mapMarker', () => {
+  const mockSetIcon = vi.fn();
+  const mockMarker = { setIcon: mockSetIcon };
+  const mockGetCenter = vi
+    .fn()
+    .mockReturnValue({ lat: 35.13488, lng: 129.0968 });
+  const mockMap = { getCenter: mockGetCenter };
+
+  const MockSize = vi.fn().mockImplementation(function (w: number, h: number) {
+    return { width: w, height: h };
+  });
+  const MockPoint = vi.fn().mockImplementation(function (x: number, y: number) {
+    return { x, y };
+  });
+  const MockMarker = vi.fn().mockImplementation(function () {
+    return mockMarker;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('naver', {
+      maps: {
+        Marker: MockMarker,
+        Size: MockSize,
+        Point: MockPoint,
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('makeMapMarker', () => {
+    it('마커를 생성하고 반환한다', () => {
+      const result = makeMapMarker(mockMap as unknown as naver.maps.Map);
+
+      expect(MockMarker).toHaveBeenCalledOnce();
+      expect(result).toBe(mockMarker);
+    });
+
+    it('마커 위치로 지도 중심을 사용한다', () => {
+      makeMapMarker(mockMap as unknown as naver.maps.Map);
+
+      expect(mockGetCenter).toHaveBeenCalledOnce();
+    });
+
+    it('마커 아이콘 생성 시 Size가 계산된다', () => {
+      makeMapMarker(mockMap as unknown as naver.maps.Map);
+
+      expect(MockSize).toHaveBeenCalledOnce();
+    });
+
+    it('마커 아이콘 생성 시 Point(anchor)가 계산된다', () => {
+      makeMapMarker(mockMap as unknown as naver.maps.Map);
+
+      expect(MockPoint).toHaveBeenCalledOnce();
+    });
+
+    it('Marker 생성자에 position, map, icon이 전달된다', () => {
+      makeMapMarker(mockMap as unknown as naver.maps.Map);
+
+      expect(MockMarker).toHaveBeenCalledWith(
+        expect.objectContaining({
+          position: expect.anything(),
+          map: mockMap,
+          icon: expect.objectContaining({ content: expect.any(String) }),
+        }),
+      );
+    });
+  });
+
+  describe('updateMarkerIcon', () => {
+    it('마커의 setIcon이 호출된다', () => {
+      updateMarkerIcon(mockMarker as unknown as naver.maps.Marker);
+
+      expect(mockSetIcon).toHaveBeenCalledOnce();
+    });
+
+    it('새로운 아이콘 객체를 setIcon에 전달한다', () => {
+      updateMarkerIcon(mockMarker as unknown as naver.maps.Marker);
+
+      expect(mockSetIcon).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.any(String) }),
+      );
+    });
+
+    it('업데이트 시 Size와 Point가 재생성된다', () => {
+      updateMarkerIcon(mockMarker as unknown as naver.maps.Marker);
+
+      expect(MockSize).toHaveBeenCalledOnce();
+      expect(MockPoint).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/widgets/map/model/transportInfo.test.ts
+++ b/src/widgets/map/model/transportInfo.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { TRANSPORT_ITEMS } from './transportInfo';
+
+describe('TRANSPORT_ITEMS', () => {
+  it('3개의 교통수단 항목을 포함한다', () => {
+    expect(TRANSPORT_ITEMS).toHaveLength(3);
+  });
+
+  it('각 항목에 고유한 id가 있다', () => {
+    const ids = TRANSPORT_ITEMS.map((item) => item.id);
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it('모든 항목에 Icon 컴포넌트가 함수로 존재한다', () => {
+    TRANSPORT_ITEMS.forEach((item) => {
+      expect(typeof item.Icon).toBe('function');
+    });
+  });
+
+  it('도보 항목이 올바른 데이터를 가진다', () => {
+    const walk = TRANSPORT_ITEMS.find((item) => item.id === 'map__walk');
+    expect(walk).toBeDefined();
+    expect(walk!.label).toBe('도보');
+    expect(walk!.lines).toEqual([
+      '부산 남구 수영로 274-16',
+      '프렌즈 스크린 부산 대연점 옆 건물',
+    ]);
+  });
+
+  it('버스 항목이 올바른 데이터를 가진다', () => {
+    const bus = TRANSPORT_ITEMS.find((item) => item.id === 'map__bus');
+    expect(bus).toBeDefined();
+    expect(bus!.label).toBe('버스');
+    expect(bus!.lines).toEqual(['대연역 정거장', '경성대학교 정거장']);
+  });
+
+  it('지하철 항목이 올바른 데이터를 가진다', () => {
+    const subway = TRANSPORT_ITEMS.find((item) => item.id === 'map__subway');
+    expect(subway).toBeDefined();
+    expect(subway!.label).toBe('지하철');
+    expect(subway!.lines).toEqual(['2호선 경성대부경대역 5번 출구']);
+  });
+});

--- a/src/widgets/map/ui/Map.nullref.test.tsx
+++ b/src/widgets/map/ui/Map.nullref.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * Map 컴포넌트 — mapRef가 null인 경우 테스트
+ *
+ * useEffect 내부 `if (mapRef.current) return makeMap(mapRef.current)`의
+ * false 분기(mapRef.current === null)를 커버합니다.
+ */
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Map from './Map';
+
+const mockMakeMap = vi.hoisted(() => vi.fn(() => vi.fn()));
+vi.mock('../model/map', () => ({ makeMap: mockMakeMap }));
+
+const mockUseRef = vi.hoisted(() =>
+  vi.fn(() => {
+    const ref = {};
+    Object.defineProperty(ref, 'current', {
+      get: () => null,
+      set: () => {
+        /* React가 ref.current를 설정하려 해도 무시 */
+      },
+      configurable: true,
+    });
+    return ref;
+  }),
+);
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+  return { ...actual, useRef: mockUseRef };
+});
+
+describe('Map — mapRef가 null인 경우', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('useRef가 null을 반환하면 makeMap이 호출되지 않는다', () => {
+    render(<Map />);
+
+    expect(mockMakeMap).not.toHaveBeenCalled();
+  });
+
+  it('useRef가 null이어도 section.map은 렌더링된다', () => {
+    const { container } = render(<Map />);
+
+    expect(container.querySelector('section.map')).toBeInTheDocument();
+  });
+});

--- a/src/widgets/map/ui/Map.test.tsx
+++ b/src/widgets/map/ui/Map.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Map from './Map';
+
+const mockMakeMap = vi.hoisted(() => vi.fn(() => vi.fn()));
+
+vi.mock('../model/map', () => ({
+  makeMap: mockMakeMap,
+}));
+
+describe('Map', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('시맨틱 구조', () => {
+    it('section.map 요소가 렌더링된다', () => {
+      const { container } = render(<Map />);
+
+      const section = container.querySelector('section');
+      expect(section).toBeInTheDocument();
+      expect(section).toHaveClass('map');
+    });
+
+    it('address.map__description 요소가 렌더링된다', () => {
+      const { container } = render(<Map />);
+
+      expect(
+        container.querySelector('address.map__description'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('제목 표시', () => {
+    it('h2 제목이 "INDUEL E&H Address"로 렌더링된다', () => {
+      render(<Map />);
+
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+        'INDUEL E&H Address',
+      );
+    });
+  });
+
+  describe('교통수단 항목 렌더링', () => {
+    it('도보 항목 레이블이 표시된다', () => {
+      render(<Map />);
+
+      expect(screen.getByText('도보')).toBeInTheDocument();
+    });
+
+    it('버스 항목 레이블이 표시된다', () => {
+      render(<Map />);
+
+      expect(screen.getByText('버스')).toBeInTheDocument();
+    });
+
+    it('지하철 항목 레이블이 표시된다', () => {
+      render(<Map />);
+
+      expect(screen.getByText('지하철')).toBeInTheDocument();
+    });
+
+    it('도보 상세 라인이 표시된다', () => {
+      render(<Map />);
+
+      expect(screen.getByText('부산 남구 수영로 274-16')).toBeInTheDocument();
+      expect(
+        screen.getByText('프렌즈 스크린 부산 대연점 옆 건물'),
+      ).toBeInTheDocument();
+    });
+
+    it('버스 상세 라인이 표시된다', () => {
+      render(<Map />);
+
+      expect(screen.getByText('대연역 정거장')).toBeInTheDocument();
+      expect(screen.getByText('경성대학교 정거장')).toBeInTheDocument();
+    });
+
+    it('지하철 상세 라인이 표시된다', () => {
+      render(<Map />);
+
+      expect(
+        screen.getByText('2호선 경성대부경대역 5번 출구'),
+      ).toBeInTheDocument();
+    });
+
+    it('3개의 li 항목이 렌더링된다', () => {
+      const { container } = render(<Map />);
+
+      expect(container.querySelectorAll('li')).toHaveLength(3);
+    });
+  });
+
+  describe('useEffect — makeMap 호출', () => {
+    it('마운트 시 makeMap이 호출된다', () => {
+      render(<Map />);
+
+      expect(mockMakeMap).toHaveBeenCalledOnce();
+    });
+
+    it('makeMap에 HTMLDivElement가 전달된다', () => {
+      render(<Map />);
+
+      expect(mockMakeMap).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+    });
+
+    it('언마운트 시 makeMap의 cleanup 함수가 호출된다', () => {
+      const mockCleanup = vi.fn();
+      mockMakeMap.mockReturnValueOnce(mockCleanup);
+
+      const { unmount } = render(<Map />);
+      unmount();
+
+      expect(mockCleanup).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('React Compiler 메모이제이션 캐시 히트', () => {
+    it('재렌더링 시에도 동일한 UI가 유지된다 (캐시 히트 분기 커버)', () => {
+      const { rerender } = render(<Map />);
+
+      rerender(<Map />);
+
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+        'INDUEL E&H Address',
+      );
+    });
+  });
+});


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #49

### Map 테스트 작성

- Map 위젯의 데이터 모델 및 UI 컴포넌트 전체에 대한 테스트 코드를 작성하였습니다.
- 지도 마커, 정보 카드, 교통 정보, null ref 처리 등을 검증합니다.

### 핵심 변화

#### 변경 전

- Map 관련 테스트 코드 없음

#### 변경 후

- 6개 테스트 파일, 총 631줄 추가

# 📋 작업 내용

- `src/widgets/map/model/map.test.ts` — 지도 모델 테스트
- `src/widgets/map/model/mapInfoCard.test.ts` — 지도 정보 카드 모델 테스트
- `src/widgets/map/model/mapMarker.test.ts` — 지도 마커 모델 테스트
- `src/widgets/map/model/transportInfo.test.ts` — 교통 정보 모델 테스트
- `src/widgets/map/ui/Map.nullref.test.tsx` — Map 컴포넌트 null ref 처리 테스트
- `src/widgets/map/ui/Map.test.tsx` — Map 컴포넌트 테스트

# 📷 스크린 샷 (선택 사항)

동작 화면 첨부