### PR TITLE
✅ test: history 도메인 테스트 코드 작성

### DIFF
--- a/src/entities/history/model/artworkData.test.ts
+++ b/src/entities/history/model/artworkData.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { ARTWORK_LIST } from './artworkData';
+
+describe('ARTWORK_LIST', () => {
+  it('하나 이상의 작품이 존재한다', () => {
+    expect(ARTWORK_LIST.length).toBeGreaterThan(0);
+  });
+
+  it('id가 0부터 순서대로 할당되어 있다', () => {
+    ARTWORK_LIST.forEach((item, index) => {
+      expect(item.id).toBe(index);
+    });
+  });
+
+  it('각 작품에 고유한 id가 있다', () => {
+    const ids = ARTWORK_LIST.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ARTWORK_LIST.length);
+  });
+
+  it('titleEng, title, description, address 필드가 비어있지 않다', () => {
+    ARTWORK_LIST.forEach((item) => {
+      expect(item.titleEng.length).toBeGreaterThan(0);
+      expect(item.title.length).toBeGreaterThan(0);
+      expect(item.description.length).toBeGreaterThan(0);
+      expect(item.address.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('time 필드는 string 타입이다', () => {
+    ARTWORK_LIST.forEach((item) => {
+      expect(typeof item.time).toBe('string');
+    });
+  });
+
+  it('content는 string 또는 string[]이다', () => {
+    ARTWORK_LIST.forEach((item) => {
+      const isStringOrArray =
+        typeof item.content === 'string' || Array.isArray(item.content);
+      expect(isStringOrArray).toBe(true);
+    });
+  });
+
+  it('area는 string[] 타입이며 각 요소는 문자열이다', () => {
+    ARTWORK_LIST.forEach((item) => {
+      expect(Array.isArray(item.area)).toBe(true);
+      item.area.forEach((a) => expect(typeof a).toBe('string'));
+    });
+  });
+
+  it('subTitle은 선택적 필드이며 string 또는 string[]이다', () => {
+    const withSubTitle = ARTWORK_LIST.filter((a) => a.subTitle !== undefined);
+    expect(withSubTitle.length).toBeGreaterThan(0);
+
+    withSubTitle.forEach((item) => {
+      const isStringOrArray =
+        typeof item.subTitle === 'string' || Array.isArray(item.subTitle);
+      expect(isStringOrArray).toBe(true);
+    });
+  });
+
+  it('time이 비어있지 않은 항목은 YYYY. MM 기반 형식을 따른다', () => {
+    // YYYY. MM / YYYY. MM ~ YYYY. MM / YYYY. MM. DD ~ YYYY. MM. DD 형식 허용
+    const timePattern =
+      /^\d{4}\.\s\d{2}(\.\s\d{2})?(\s~\s\d{4}\.\s\d{2}(\.\s\d{2})?)?$/;
+    ARTWORK_LIST.filter((item) => item.time !== '').forEach((item) => {
+      expect(item.time).toMatch(timePattern);
+    });
+  });
+});

--- a/src/entities/history/model/awardHistoryData.test.ts
+++ b/src/entities/history/model/awardHistoryData.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { AWARD_HISTORY_LIST } from './awardHistoryData';
+
+describe('AWARD_HISTORY_LIST', () => {
+  it('하나 이상의 항목이 존재한다', () => {
+    expect(AWARD_HISTORY_LIST.length).toBeGreaterThan(0);
+  });
+
+  it('모든 항목에 year(number)와 contents(string[])가 있다', () => {
+    AWARD_HISTORY_LIST.forEach((item) => {
+      expect(typeof item.year).toBe('number');
+      expect(Array.isArray(item.contents)).toBe(true);
+    });
+  });
+
+  it('year는 회사 창립(2000년) 이후 값이다', () => {
+    AWARD_HISTORY_LIST.forEach((item) => {
+      expect(item.year).toBeGreaterThanOrEqual(2000);
+    });
+  });
+
+  it('year가 오름차순으로 정렬되어 있다', () => {
+    for (let i = 1; i < AWARD_HISTORY_LIST.length; i++) {
+      expect(AWARD_HISTORY_LIST[i].year).toBeGreaterThanOrEqual(
+        AWARD_HISTORY_LIST[i - 1].year,
+      );
+    }
+  });
+
+  it('각 항목의 contents에 하나 이상의 내용이 있다', () => {
+    AWARD_HISTORY_LIST.forEach((item) => {
+      expect(item.contents.length).toBeGreaterThan(0);
+      item.contents.forEach((c) => {
+        expect(typeof c).toBe('string');
+        expect(c.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  it('year 값이 중복되지 않는다', () => {
+    const years = AWARD_HISTORY_LIST.map((a) => a.year);
+    expect(new Set(years).size).toBe(AWARD_HISTORY_LIST.length);
+  });
+});

--- a/src/entities/history/model/timelineData.test.ts
+++ b/src/entities/history/model/timelineData.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { TIMELINE_LIST } from './timelineData';
+
+describe('TIMELINE_LIST', () => {
+  it('하나 이상의 항목이 존재한다', () => {
+    expect(TIMELINE_LIST.length).toBeGreaterThan(0);
+  });
+
+  it('모든 항목에 date와 name이 비어있지 않은 문자열로 존재한다', () => {
+    TIMELINE_LIST.forEach((item) => {
+      expect(typeof item.date).toBe('string');
+      expect(item.date.length).toBeGreaterThan(0);
+      expect(typeof item.name).toBe('string');
+      expect(item.name.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('date는 YYYY.MM.DD 형식이다', () => {
+    const datePattern = /^\d{4}\.\d{2}\.\d{2}$/;
+    TIMELINE_LIST.forEach((item) => {
+      expect(item.date).toMatch(datePattern);
+    });
+  });
+
+  it('date가 오름차순으로 정렬되어 있다', () => {
+    for (let i = 1; i < TIMELINE_LIST.length; i++) {
+      expect(TIMELINE_LIST[i].date >= TIMELINE_LIST[i - 1].date).toBe(true);
+    }
+  });
+
+  it('회사 창립일(2000.04.27)이 첫 번째 항목이다', () => {
+    expect(TIMELINE_LIST[0].date).toBe('2000.04.27');
+  });
+});

--- a/src/widgets/history/model/animation/buildRapidSteps.test.ts
+++ b/src/widgets/history/model/animation/buildRapidSteps.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest';
+
+import { MIN_RAPID_FLIPS } from '../constants';
+import { buildRapidSteps } from './buildRapidSteps';
+
+// 테스트용 기본 파라미터
+const base = {
+  activeItem: 'List' as const,
+  activeIndex: 0,
+  currentPageIndex: 0,
+  totalPages: 1,
+  targetItem: 'Content' as const,
+  targetPageIndex: 0,
+  targetTotalPages: 5,
+  direction: 'forward' as const,
+};
+
+describe('buildRapidSteps', () => {
+  describe('기본 보장 조건', () => {
+    it('결과 길이가 항상 MIN_RAPID_FLIPS 이상이다', () => {
+      const steps = buildRapidSteps(base);
+      expect(steps.length).toBeGreaterThanOrEqual(MIN_RAPID_FLIPS);
+    });
+
+    it('마지막 스텝은 항상 targetItem + targetPageIndex이다', () => {
+      const steps = buildRapidSteps(base);
+      const last = steps[steps.length - 1];
+      expect(last.item).toBe(base.targetItem);
+      expect(last.pageIndex).toBe(base.targetPageIndex);
+    });
+
+    it('MIN_RAPID_FLIPS 상수는 3이다', () => {
+      expect(MIN_RAPID_FLIPS).toBe(3);
+    });
+  });
+
+  describe('같은 카테고리 내 이동 (targetIndex === activeIndex)', () => {
+    it('동일 카테고리 이동 시 결과가 MIN_RAPID_FLIPS 이상이다', () => {
+      const steps = buildRapidSteps({
+        ...base,
+        activeItem: 'Content',
+        activeIndex: 1,
+        currentPageIndex: 0,
+        totalPages: 5,
+        targetItem: 'Content',
+        targetPageIndex: 3,
+        targetTotalPages: 5,
+        direction: 'forward',
+      });
+      expect(steps.length).toBeGreaterThanOrEqual(MIN_RAPID_FLIPS);
+    });
+
+    it('동일 카테고리 이동 시 마지막 스텝이 목표 pageIndex이다', () => {
+      const steps = buildRapidSteps({
+        ...base,
+        activeItem: 'Content',
+        activeIndex: 1,
+        currentPageIndex: 0,
+        totalPages: 5,
+        targetItem: 'Content',
+        targetPageIndex: 3,
+        targetTotalPages: 5,
+        direction: 'forward',
+      });
+      const last = steps[steps.length - 1];
+      expect(last.item).toBe('Content');
+      expect(last.pageIndex).toBe(3);
+    });
+  });
+
+  describe('forward 방향 카테고리 횡단', () => {
+    it('List → Award 이동 시 중간 카테고리(Content, Timeline)를 거친다', () => {
+      const steps = buildRapidSteps({
+        activeItem: 'List',
+        activeIndex: 0,
+        currentPageIndex: 0,
+        totalPages: 1,
+        targetItem: 'Award',
+        targetPageIndex: 0,
+        targetTotalPages: 2,
+        direction: 'forward',
+      });
+      const items = steps.map((s) => s.item);
+      // Content와 Timeline이 경로에 포함되어야 함
+      expect(items).toContain('Content');
+      expect(items).toContain('Timeline');
+      expect(items).toContain('Award');
+    });
+
+    it('List → Content 이동 시 마지막 스텝이 Content이다', () => {
+      const steps = buildRapidSteps({ ...base, direction: 'forward' });
+      expect(steps[steps.length - 1].item).toBe('Content');
+    });
+  });
+
+  describe('backward 방향 카테고리 횡단', () => {
+    it('Award → List 이동 시 중간 카테고리(Timeline, Content)를 거친다', () => {
+      const steps = buildRapidSteps({
+        activeItem: 'Award',
+        activeIndex: 3,
+        currentPageIndex: 0,
+        totalPages: 2,
+        targetItem: 'List',
+        targetPageIndex: 0,
+        targetTotalPages: 1,
+        direction: 'backward',
+      });
+      const items = steps.map((s) => s.item);
+      expect(items).toContain('Timeline');
+      expect(items).toContain('Content');
+      expect(items).toContain('List');
+    });
+
+    it('backward 이동 시에도 마지막 스텝은 targetItem이다', () => {
+      const steps = buildRapidSteps({
+        activeItem: 'Content',
+        activeIndex: 1,
+        currentPageIndex: 2,
+        totalPages: 5,
+        targetItem: 'List',
+        targetPageIndex: 0,
+        targetTotalPages: 1,
+        direction: 'backward',
+      });
+      const last = steps[steps.length - 1];
+      expect(last.item).toBe('List');
+      expect(last.pageIndex).toBe(0);
+    });
+  });
+
+  describe('prePadding: 현재 카테고리 내 페이지 패딩', () => {
+    it('현재 카테고리에 다음 페이지가 있으면 패딩에 포함된다', () => {
+      const steps = buildRapidSteps({
+        activeItem: 'Content',
+        activeIndex: 1,
+        currentPageIndex: 0,
+        totalPages: 10, // 페이지 여유 있음
+        targetItem: 'Timeline',
+        targetPageIndex: 0,
+        targetTotalPages: 1,
+        direction: 'forward',
+      });
+      // 첫 번째 스텝이 Content(현재 카테고리) 페이지 패딩이어야 함
+      expect(steps[0].item).toBe('Content');
+      expect(steps[steps.length - 1].item).toBe('Timeline');
+    });
+
+    it('backward 패딩은 현재 pageIndex보다 작은 페이지를 사용한다', () => {
+      const steps = buildRapidSteps({
+        activeItem: 'Content',
+        activeIndex: 1,
+        currentPageIndex: 5, // 뒤로 갈 여유 있음
+        totalPages: 10,
+        targetItem: 'List',
+        targetPageIndex: 0,
+        targetTotalPages: 1,
+        direction: 'backward',
+      });
+      // prePadding 스텝의 pageIndex가 currentPageIndex보다 작아야 함
+      const contentSteps = steps.filter(
+        (s, i) => s.item === 'Content' && i < steps.length - 1,
+      );
+      contentSteps.forEach((s) => {
+        expect(s.pageIndex).toBeLessThan(5);
+      });
+    });
+  });
+
+  describe('제자리 플립: 스텝이 MIN_RAPID_FLIPS 미만일 때 보충', () => {
+    it('패딩 없이 crossStep 1개뿐이면 activeItem 제자리 스텝으로 채운다', () => {
+      // List(totalPages=1) → Content(pageIndex=0), forward
+      // crossSteps=1, prePadding=0(totalPages 1이라 다음 페이지 없음), postPadding 가능
+      const steps = buildRapidSteps({
+        activeItem: 'List',
+        activeIndex: 0,
+        currentPageIndex: 0,
+        totalPages: 1,
+        targetItem: 'Content',
+        targetPageIndex: 0,
+        targetTotalPages: 1, // targetTotalPages도 1로 강제하여 postPadding 방지
+        direction: 'forward',
+      });
+      expect(steps.length).toBeGreaterThanOrEqual(MIN_RAPID_FLIPS);
+      // 제자리 플립 스텝은 activeItem(List) + currentPageIndex(0)이어야 함
+      const fillerSteps = steps.slice(0, steps.length - 1);
+      const hasFiller = fillerSteps.some(
+        (s) => s.item === 'List' && s.pageIndex === 0,
+      );
+      expect(hasFiller).toBe(true);
+    });
+  });
+
+  describe('postPadding: 타겟 카테고리 내 페이지 패딩', () => {
+    it('forward 방향에서 postPadding은 마지막 스텝 직전에 삽입된다', () => {
+      const steps = buildRapidSteps({
+        activeItem: 'List',
+        activeIndex: 0,
+        currentPageIndex: 0,
+        totalPages: 1,
+        targetItem: 'Content',
+        targetPageIndex: 0,
+        targetTotalPages: 10, // targetTotalPages가 크면 postPadding 생성 가능
+        direction: 'forward',
+      });
+      // 마지막 스텝이 targetItem + targetPageIndex(0)
+      const last = steps[steps.length - 1];
+      expect(last.item).toBe('Content');
+      expect(last.pageIndex).toBe(0);
+    });
+  });
+
+  describe('엣지 케이스', () => {
+    it('인접한 카테고리 간 이동(List→Content)은 정확히 1개의 crossStep을 생성한다', () => {
+      const steps = buildRapidSteps({
+        ...base,
+        totalPages: 1,
+        targetTotalPages: 1,
+        direction: 'forward',
+      });
+      // crossSteps = 1 (Content만), 전체 최소 MIN_RAPID_FLIPS
+      expect(steps.length).toBeGreaterThanOrEqual(MIN_RAPID_FLIPS);
+      expect(steps[steps.length - 1].item).toBe('Content');
+    });
+
+    it('현재 pageIndex가 0이고 backward일 때 prePadding이 생성되지 않는다', () => {
+      const steps = buildRapidSteps({
+        activeItem: 'Content',
+        activeIndex: 1,
+        currentPageIndex: 0, // 이전 페이지 없음
+        totalPages: 5,
+        targetItem: 'List',
+        targetPageIndex: 0,
+        targetTotalPages: 1,
+        direction: 'backward',
+      });
+      // prePadding 없이도 MIN_RAPID_FLIPS 이상
+      expect(steps.length).toBeGreaterThanOrEqual(MIN_RAPID_FLIPS);
+    });
+  });
+});

--- a/src/widgets/history/model/helpers.test.ts
+++ b/src/widgets/history/model/helpers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { getArtworkIndex } from './helpers';
+
+// import.meta.glob 의존성을 가진 함수들(getThumbnailImage, getAllContentImages, preloadContentImages)은
+// Vite 런타임 기능에 의존하므로 getArtworkIndex 순수 함수만 단위 테스트한다.
+
+describe('getArtworkIndex', () => {
+  it('pageIndex 0, left 사이드 → 0을 반환한다', () => {
+    expect(getArtworkIndex(0, 'left')).toBe(0);
+  });
+
+  it('pageIndex 0, right 사이드 → 1을 반환한다', () => {
+    expect(getArtworkIndex(0, 'right')).toBe(1);
+  });
+
+  it('pageIndex 1, left 사이드 → 2를 반환한다', () => {
+    expect(getArtworkIndex(1, 'left')).toBe(2);
+  });
+
+  it('pageIndex 1, right 사이드 → 3을 반환한다', () => {
+    expect(getArtworkIndex(1, 'right')).toBe(3);
+  });
+
+  it('pageIndex n, left 사이드 → n*2를 반환한다', () => {
+    for (let n = 0; n <= 10; n++) {
+      expect(getArtworkIndex(n, 'left')).toBe(n * 2);
+    }
+  });
+
+  it('pageIndex n, right 사이드 → n*2+1을 반환한다', () => {
+    for (let n = 0; n <= 10; n++) {
+      expect(getArtworkIndex(n, 'right')).toBe(n * 2 + 1);
+    }
+  });
+
+  it('left 사이드 인덱스는 항상 짝수이다', () => {
+    for (let n = 0; n <= 5; n++) {
+      expect(getArtworkIndex(n, 'left') % 2).toBe(0);
+    }
+  });
+
+  it('right 사이드 인덱스는 항상 홀수이다', () => {
+    for (let n = 0; n <= 5; n++) {
+      expect(getArtworkIndex(n, 'right') % 2).toBe(1);
+    }
+  });
+
+  it('같은 pageIndex에서 right 인덱스는 left 인덱스보다 1 크다', () => {
+    for (let n = 0; n <= 5; n++) {
+      expect(getArtworkIndex(n, 'right') - getArtworkIndex(n, 'left')).toBe(1);
+    }
+  });
+});

--- a/src/widgets/history/model/pageRegistry.test.ts
+++ b/src/widgets/history/model/pageRegistry.test.ts
@@ -1,0 +1,95 @@
+import { artworks } from '@entities/history';
+import { describe, expect, it } from 'vitest';
+
+import {
+  AWARD_YEAR_RANGES_BY_BREAKPOINT,
+  getPageRegistry,
+} from './pageRegistry';
+
+describe('AWARD_YEAR_RANGES_BY_BREAKPOINT', () => {
+  it('desktop과 tablet 브레이크포인트 키가 존재한다', () => {
+    expect(AWARD_YEAR_RANGES_BY_BREAKPOINT).toHaveProperty('desktop');
+    expect(AWARD_YEAR_RANGES_BY_BREAKPOINT).toHaveProperty('tablet');
+  });
+
+  it('각 브레이크포인트의 범위는 [시작연도, 끝연도] 쌍의 배열이다', () => {
+    (['desktop', 'tablet'] as const).forEach((bp) => {
+      AWARD_YEAR_RANGES_BY_BREAKPOINT[bp].forEach((range) => {
+        expect(range).toHaveLength(2);
+        expect(range[0]).toBeLessThanOrEqual(range[1]);
+        expect(typeof range[0]).toBe('number');
+        expect(typeof range[1]).toBe('number');
+      });
+    });
+  });
+
+  it('desktop보다 tablet의 범위 개수가 더 많다(더 촘촘하게 분할)', () => {
+    expect(AWARD_YEAR_RANGES_BY_BREAKPOINT.tablet.length).toBeGreaterThan(
+      AWARD_YEAR_RANGES_BY_BREAKPOINT.desktop.length,
+    );
+  });
+
+  it('desktop 범위들은 연속적으로 이어진다', () => {
+    const ranges = AWARD_YEAR_RANGES_BY_BREAKPOINT.desktop;
+    for (let i = 1; i < ranges.length; i++) {
+      expect(ranges[i][0]).toBe(ranges[i - 1][1] + 1);
+    }
+  });
+
+  it('tablet 범위들은 연속적으로 이어진다', () => {
+    const ranges = AWARD_YEAR_RANGES_BY_BREAKPOINT.tablet;
+    for (let i = 1; i < ranges.length; i++) {
+      expect(ranges[i][0]).toBe(ranges[i - 1][1] + 1);
+    }
+  });
+});
+
+describe('getPageRegistry', () => {
+  it('List, Content, Timeline, Award 네 개의 카테고리를 반환한다', () => {
+    const registry = getPageRegistry('desktop');
+    expect(registry).toHaveProperty('List');
+    expect(registry).toHaveProperty('Content');
+    expect(registry).toHaveProperty('Timeline');
+    expect(registry).toHaveProperty('Award');
+  });
+
+  it('List와 Timeline의 totalPages는 1이다', () => {
+    const registry = getPageRegistry('desktop');
+    expect(registry.List.totalPages).toBe(1);
+    expect(registry.Timeline.totalPages).toBe(1);
+  });
+
+  it('Content의 totalPages는 작품 수를 2로 나눈 올림값이다', () => {
+    const registry = getPageRegistry('desktop');
+    expect(registry.Content.totalPages).toBe(Math.ceil(artworks.length / 2));
+  });
+
+  it('desktop Award의 totalPages는 범위 개수를 2로 나눈 올림값이다', () => {
+    const registry = getPageRegistry('desktop');
+    const desktopRanges = AWARD_YEAR_RANGES_BY_BREAKPOINT.desktop;
+    expect(registry.Award.totalPages).toBe(Math.ceil(desktopRanges.length / 2));
+  });
+
+  it('tablet Award의 totalPages는 desktop보다 크다', () => {
+    const desktopRegistry = getPageRegistry('desktop');
+    const tabletRegistry = getPageRegistry('tablet');
+    expect(tabletRegistry.Award.totalPages).toBeGreaterThan(
+      desktopRegistry.Award.totalPages,
+    );
+  });
+
+  it('동일한 브레이크포인트로 여러 번 호출하면 같은 객체를 반환한다(캐시)', () => {
+    const first = getPageRegistry('desktop');
+    const second = getPageRegistry('desktop');
+    expect(first).toBe(second);
+  });
+
+  it('모든 totalPages는 1 이상이다', () => {
+    (['desktop', 'tablet'] as const).forEach((bp) => {
+      const registry = getPageRegistry(bp);
+      Object.values(registry).forEach(({ totalPages }) => {
+        expect(totalPages).toBeGreaterThanOrEqual(1);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #23
- #49

### history 도메인 테스트 작성

- history 도메인 전반에 걸쳐 6개 테스트 파일, 56개 테스트 케이스 작성
- 순수 함수 위주로 구성하여 UI 의존성 없이 빠르게 실행

### 핵심 변화

#### 변경 전

- history 도메인 테스트 파일 없음

#### 변경 후

| 파일 | 테스트 수 | 대상 |
|---|---|---|
| `entities/history/model/artworkData.test.ts` | 9 | `ARTWORK_LIST` 데이터 무결성 |
| `entities/history/model/awardHistoryData.test.ts` | 6 | `AWARD_HISTORY_LIST` 데이터 무결성 |
| `entities/history/model/timelineData.test.ts` | 5 | `TIMELINE_LIST` 데이터 무결성 |
| `widgets/history/model/helpers.test.ts` | 9 | `getArtworkIndex` 순수 함수 |
| `widgets/history/model/pageRegistry.test.ts` | 12 | `getPageRegistry` + `AWARD_YEAR_RANGES_BY_BREAKPOINT` |
| `widgets/history/model/animation/buildRapidSteps.test.ts` | 15 | `buildRapidSteps` 순수 함수 (핵심 네비게이션 로직) |

# 📋 작업 내용

- `buildRapidSteps` — 카테고리 횡단, prePadding/postPadding, 제자리 플립 보충 등 핵심 분기 모두 검증
- `getPageRegistry` — 캐시 동작(동일 객체 참조 반환), 브레이크포인트별 페이지 수 계산 검증
- `ARTWORK_LIST` — `time` 빈 문자열, `area` 빈 배열 엣지 케이스 반영
- `import.meta.glob` Vite 런타임 의존 함수(`getThumbnailImage` 등)는 테스트 제외 처리 및 주석으로 사유 명시