### PR TITLE
✅ test: patent 도메인 테스트 코드 작성

### DIFF
--- a/src/widgets/patent/model/PatentListData.test.ts
+++ b/src/widgets/patent/model/PatentListData.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import PATENT_LIST_DATA from './PatentListData';
+
+describe('PATENT_LIST_DATA', () => {
+  it('하나 이상의 항목이 존재한다', () => {
+    expect(PATENT_LIST_DATA.length).toBeGreaterThan(0);
+  });
+
+  it('모든 항목은 비어있지 않은 문자열이다', () => {
+    PATENT_LIST_DATA.forEach((item) => {
+      expect(typeof item).toBe('string');
+      expect(item.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('모든 항목은 10-XXXXXXX-00-00 형식의 특허번호로 시작한다', () => {
+    const patentNumberPattern = /^10-\d{7}-\d{2}-\d{2}/;
+    PATENT_LIST_DATA.forEach((item) => {
+      expect(item).toMatch(patentNumberPattern);
+    });
+  });
+
+  it('모든 항목은 특허번호 뒤에 공백과 명칭이 있다', () => {
+    // 형식: "10-XXXXXXX-00-00 [명칭]"
+    const fullPattern = /^10-\d{7}-\d{2}-\d{2} .+$/;
+    PATENT_LIST_DATA.forEach((item) => {
+      expect(item).toMatch(fullPattern);
+    });
+  });
+});

--- a/src/widgets/patent/ui/Patent.test.tsx
+++ b/src/widgets/patent/ui/Patent.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import PATENT_LIST_DATA from '../model/PatentListData';
+import Patent from './Patent';
+
+// .webp 이미지 import 모킹
+vi.mock('../model/PatentImgData', () => ({
+  default: ['img-0', 'img-1', 'img-2', 'img-3', 'img-4'],
+}));
+
+// react-icons 모킹 (SVG 렌더링 불필요)
+vi.mock('react-icons/io', () => ({
+  IoIosArrowBack: () => <span data-testid='icon-back' />,
+  IoIosArrowForward: () => <span data-testid='icon-forward' />,
+  IoIosArrowDown: () => <span data-testid='icon-down' />,
+  IoIosArrowUp: () => <span data-testid='icon-up' />,
+}));
+
+describe('Patent', () => {
+  describe('시맨틱 구조', () => {
+    it('최상위 요소가 section.patent로 렌더링된다', () => {
+      const { container } = render(<Patent />);
+
+      expect(container.querySelector('section.patent')).toBeInTheDocument();
+    });
+  });
+
+  describe('타이틀', () => {
+    it('"Patent" 텍스트가 표시된다', () => {
+      render(<Patent />);
+
+      expect(screen.getByText('Patent')).toBeInTheDocument();
+    });
+
+    it('유효 특허 건수가 표시된다', () => {
+      render(<Patent />);
+
+      // PATENT_IMG_DATA mock의 길이 = 5
+      expect(screen.getByText(/유효 특허 5건/)).toBeInTheDocument();
+    });
+
+    it('권리 소멸 건수가 표시된다', () => {
+      render(<Patent />);
+
+      expect(
+        screen.getByText(
+          new RegExp(`권리 소멸\\s*${PATENT_LIST_DATA.length}건`),
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('하위 컴포넌트', () => {
+    it('캐러셀이 렌더링된다', () => {
+      const { container } = render(<Patent />);
+
+      expect(container.querySelector('.patent__carousel')).toBeInTheDocument();
+    });
+
+    it('권리 소멸 목록 영역이 렌더링된다', () => {
+      const { container } = render(<Patent />);
+
+      expect(
+        container.querySelector('.patent__content-sub'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/widgets/patent/ui/PatentCarousel.test.tsx
+++ b/src/widgets/patent/ui/PatentCarousel.test.tsx
@@ -1,0 +1,168 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import PatentCarousel from './PatentCarousel';
+
+const mockImages = ['img-0', 'img-1', 'img-2', 'img-3', 'img-4'];
+
+// offset별 CSS 클래스 조회 헬퍼
+function getCardByOffset(container: HTMLElement, offset: number) {
+  return container.querySelector(`.patent__carousel-card--offset-${offset}`);
+}
+
+describe('PatentCarousel', () => {
+  describe('초기 렌더링', () => {
+    it('이전/다음 버튼이 렌더링된다', () => {
+      const { container } = render(<PatentCarousel images={mockImages} />);
+
+      const buttons = container.querySelectorAll('.patent__carousel-btn');
+      expect(buttons).toHaveLength(2);
+    });
+
+    it('초기 activeIndex는 2이다 (가운데 카드가 offset-0)', () => {
+      const { container } = render(<PatentCarousel images={mockImages} />);
+
+      expect(getCardByOffset(container, 0)).toBeInTheDocument();
+    });
+
+    it('5개 이미지 기준 모든 카드가 렌더링된다 (|offset| ≤ 2)', () => {
+      const { container } = render(<PatentCarousel images={mockImages} />);
+
+      const cards = container.querySelectorAll('.patent__carousel-card');
+      expect(cards).toHaveLength(5);
+    });
+
+    it('각 카드에 img 태그가 렌더링된다', () => {
+      render(<PatentCarousel images={mockImages} />);
+
+      const images = screen.getAllByRole('img');
+      expect(images).toHaveLength(5);
+    });
+  });
+
+  describe('이전 버튼 클릭', () => {
+    it('클릭 시 activeIndex가 1 감소한다 (offset-0 카드가 변경)', () => {
+      const { container } = render(<PatentCarousel images={mockImages} />);
+      const [prevBtn] = container.querySelectorAll('.patent__carousel-btn');
+
+      // 초기 activeIndex=2, img-2가 offset-0
+      expect(
+        getCardByOffset(container, 0)?.querySelector('img'),
+      ).toHaveAttribute('src', 'img-2');
+
+      fireEvent.click(prevBtn);
+
+      // activeIndex=1, img-1이 offset-0
+      expect(
+        getCardByOffset(container, 0)?.querySelector('img'),
+      ).toHaveAttribute('src', 'img-1');
+    });
+
+    it('activeIndex가 0일 때 클릭하면 마지막 카드로 순환한다', () => {
+      const { container } = render(<PatentCarousel images={mockImages} />);
+      const [prevBtn] = container.querySelectorAll('.patent__carousel-btn');
+
+      // activeIndex 0으로 이동 (2번 클릭)
+      fireEvent.click(prevBtn);
+      fireEvent.click(prevBtn);
+
+      // activeIndex=0, img-0이 offset-0
+      expect(
+        getCardByOffset(container, 0)?.querySelector('img'),
+      ).toHaveAttribute('src', 'img-0');
+
+      fireEvent.click(prevBtn);
+
+      // activeIndex=(0-1+5)%5=4, img-4가 offset-0
+      expect(
+        getCardByOffset(container, 0)?.querySelector('img'),
+      ).toHaveAttribute('src', 'img-4');
+    });
+  });
+
+  describe('다음 버튼 클릭', () => {
+    it('클릭 시 activeIndex가 1 증가한다', () => {
+      const { container } = render(<PatentCarousel images={mockImages} />);
+      const buttons = container.querySelectorAll('.patent__carousel-btn');
+      const nextBtn = buttons[1];
+
+      // 초기 activeIndex=2
+      fireEvent.click(nextBtn);
+
+      // activeIndex=3, img-3이 offset-0
+      expect(
+        getCardByOffset(container, 0)?.querySelector('img'),
+      ).toHaveAttribute('src', 'img-3');
+    });
+
+    it('마지막 카드에서 클릭하면 첫 번째 카드로 순환한다', () => {
+      const { container } = render(<PatentCarousel images={mockImages} />);
+      const buttons = container.querySelectorAll('.patent__carousel-btn');
+      const nextBtn = buttons[1];
+
+      // activeIndex를 4로 이동 (2번 클릭)
+      fireEvent.click(nextBtn);
+      fireEvent.click(nextBtn);
+
+      // activeIndex=4
+      expect(
+        getCardByOffset(container, 0)?.querySelector('img'),
+      ).toHaveAttribute('src', 'img-4');
+
+      fireEvent.click(nextBtn);
+
+      // activeIndex=(4+1)%5=0, img-0이 offset-0
+      expect(
+        getCardByOffset(container, 0)?.querySelector('img'),
+      ).toHaveAttribute('src', 'img-0');
+    });
+  });
+
+  describe('카드 클릭', () => {
+    it('카드 클릭 시 해당 카드가 activeIndex가 된다', () => {
+      const { container } = render(<PatentCarousel images={mockImages} />);
+
+      // 초기 activeIndex=2, offset-1 카드는 img-3
+      const offset1Card = getCardByOffset(container, 1);
+      expect(offset1Card?.querySelector('img')).toHaveAttribute('src', 'img-3');
+
+      fireEvent.click(offset1Card!);
+
+      // img-3이 offset-0이 되어야 함
+      expect(
+        getCardByOffset(container, 0)?.querySelector('img'),
+      ).toHaveAttribute('src', 'img-3');
+    });
+  });
+
+  describe('getOffset 순환 계산', () => {
+    it('activeIndex=0일 때 마지막 이미지가 offset--1로 렌더링된다', () => {
+      const { container } = render(<PatentCarousel images={mockImages} />);
+      const [prevBtn] = container.querySelectorAll('.patent__carousel-btn');
+
+      // activeIndex를 0으로 이동
+      fireEvent.click(prevBtn);
+      fireEvent.click(prevBtn);
+
+      // activeIndex=0, img-4의 offset: 4-0=4 > Math.floor(5/2)=2 → 4-5=-1
+      expect(
+        getCardByOffset(container, -1)?.querySelector('img'),
+      ).toHaveAttribute('src', 'img-4');
+    });
+
+    it('activeIndex=4일 때 첫 번째 이미지가 offset-1로 렌더링된다', () => {
+      const { container } = render(<PatentCarousel images={mockImages} />);
+      const buttons = container.querySelectorAll('.patent__carousel-btn');
+      const nextBtn = buttons[1];
+
+      // activeIndex를 4로 이동
+      fireEvent.click(nextBtn);
+      fireEvent.click(nextBtn);
+
+      // activeIndex=4, img-0의 offset: 0-4=-4 < -Math.floor(5/2)=-2 → -4+5=1
+      expect(
+        getCardByOffset(container, 1)?.querySelector('img'),
+      ).toHaveAttribute('src', 'img-0');
+    });
+  });
+});

--- a/src/widgets/patent/ui/PatentList.test.tsx
+++ b/src/widgets/patent/ui/PatentList.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import PATENT_LIST_DATA from '../model/PatentListData';
+import PatentList from './PatentList';
+
+describe('PatentList', () => {
+  describe('초기 상태', () => {
+    it('제목에 권리 소멸 건수가 표시된다', () => {
+      render(<PatentList />);
+
+      expect(
+        screen.getByText(`권리 소멸 목록 (${PATENT_LIST_DATA.length}건)`),
+      ).toBeInTheDocument();
+    });
+
+    it('초기에 목록이 닫혀있다', () => {
+      render(<PatentList />);
+
+      expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+
+    it('토글 버튼이 렌더링된다', () => {
+      render(<PatentList />);
+
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+  });
+
+  describe('토글 동작', () => {
+    it('버튼 클릭 시 목록이 열린다', () => {
+      render(<PatentList />);
+
+      fireEvent.click(screen.getByRole('button'));
+
+      expect(screen.getByRole('list')).toBeInTheDocument();
+    });
+
+    it('열린 상태에서 버튼 클릭 시 목록이 닫힌다', () => {
+      render(<PatentList />);
+      const button = screen.getByRole('button');
+
+      fireEvent.click(button);
+      fireEvent.click(button);
+
+      expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('목록 내용', () => {
+    it('목록이 열리면 모든 항목이 렌더링된다', () => {
+      render(<PatentList />);
+
+      fireEvent.click(screen.getByRole('button'));
+
+      const items = screen.getAllByRole('listitem');
+      expect(items).toHaveLength(PATENT_LIST_DATA.length);
+    });
+
+    it('목록이 열리면 각 특허 항목 텍스트가 표시된다', () => {
+      render(<PatentList />);
+
+      fireEvent.click(screen.getByRole('button'));
+
+      const uniqueItems = [...new Set(PATENT_LIST_DATA)];
+      uniqueItems.forEach((item) => {
+        expect(screen.getAllByText(item).length).toBeGreaterThan(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #49

### patent 도메인 테스트 작성

- patent 도메인 전반에 걸쳐 4개 테스트 파일, 28개 테스트 케이스 작성
- 데이터 무결성, UI 인터랙션, 순환 carousel 로직을 모두 검증

### 핵심 변화

#### 변경 전

- patent 도메인 테스트 파일 없음

#### 변경 후

| 파일 | 테스트 수 | 대상 |
|---|---|---|
| `model/PatentListData.test.ts` | 4 | `PATENT_LIST_DATA` 데이터 무결성 (특허번호 형식 검증) |
| `ui/PatentList.test.tsx` | 7 | 토글 열기/닫기, 목록 렌더링 |
| `ui/PatentCarousel.test.tsx` | 11 | 이전/다음 버튼, 카드 클릭, `getOffset` 순환 로직 |
| `ui/Patent.test.tsx` | 6 | 타이틀 건수 표시, 하위 컴포넌트 렌더링 |

# 📋 작업 내용

- `PatentCarousel` — `getOffset` 순환 계산을 `activeIndex=0/4` 엣지 케이스까지 CSS 클래스로 검증
- `PatentList` — 초기 닫힘 상태, 토글 2회(열기/닫기), 목록 전체 항목 렌더링 검증
- `Patent` — `.webp` import를 mock 처리, 타이틀에 표시되는 유효 특허/권리 소멸 건수 검증
- `PATENT_LIST_DATA` — 중복 항목 존재 확인 후 `getAllByText` 로 처리