### PR TITLE
🧹 clean: 불필요 테스트 코드 제거

### DIFF
--- a/src/entities/award/model/awardList.test.ts
+++ b/src/entities/award/model/awardList.test.ts
@@ -3,10 +3,6 @@ import { describe, expect, it } from 'vitest';
 import { AWARD_LIST } from './awardList';
 
 describe('AWARD_LIST', () => {
-  it('8개의 항목을 포함한다', () => {
-    expect(AWARD_LIST).toHaveLength(8);
-  });
-
   it('각 항목에 고유한 id가 있다', () => {
     const ids = AWARD_LIST.map((a) => a.id);
     expect(new Set(ids).size).toBe(8);
@@ -30,11 +26,5 @@ describe('AWARD_LIST', () => {
     );
     expect(withSerial.length).toBeGreaterThan(0);
     expect(withoutSerial.length).toBeGreaterThan(0);
-  });
-
-  it('id가 0부터 7까지 순서대로 할당되어 있다', () => {
-    AWARD_LIST.forEach((item, index) => {
-      expect(item.id).toBe(index);
-    });
   });
 });

--- a/src/entities/history/model/artworkData.test.ts
+++ b/src/entities/history/model/artworkData.test.ts
@@ -27,27 +27,6 @@ describe('ARTWORK_LIST', () => {
     });
   });
 
-  it('time 필드는 string 타입이다', () => {
-    ARTWORK_LIST.forEach((item) => {
-      expect(typeof item.time).toBe('string');
-    });
-  });
-
-  it('content는 string 또는 string[]이다', () => {
-    ARTWORK_LIST.forEach((item) => {
-      const isStringOrArray =
-        typeof item.content === 'string' || Array.isArray(item.content);
-      expect(isStringOrArray).toBe(true);
-    });
-  });
-
-  it('area는 string[] 타입이며 각 요소는 문자열이다', () => {
-    ARTWORK_LIST.forEach((item) => {
-      expect(Array.isArray(item.area)).toBe(true);
-      item.area.forEach((a) => expect(typeof a).toBe('string'));
-    });
-  });
-
   it('subTitle은 선택적 필드이며 string 또는 string[]이다', () => {
     const withSubTitle = ARTWORK_LIST.filter((a) => a.subTitle !== undefined);
     expect(withSubTitle.length).toBeGreaterThan(0);

--- a/src/entities/history/model/awardHistoryData.test.ts
+++ b/src/entities/history/model/awardHistoryData.test.ts
@@ -7,13 +7,6 @@ describe('AWARD_HISTORY_LIST', () => {
     expect(AWARD_HISTORY_LIST.length).toBeGreaterThan(0);
   });
 
-  it('모든 항목에 year(number)와 contents(string[])가 있다', () => {
-    AWARD_HISTORY_LIST.forEach((item) => {
-      expect(typeof item.year).toBe('number');
-      expect(Array.isArray(item.contents)).toBe(true);
-    });
-  });
-
   it('year는 회사 창립(2000년) 이후 값이다', () => {
     AWARD_HISTORY_LIST.forEach((item) => {
       expect(item.year).toBeGreaterThanOrEqual(2000);

--- a/src/features/award/model/constant.test.ts
+++ b/src/features/award/model/constant.test.ts
@@ -4,10 +4,6 @@ import { describe, expect, it } from 'vitest';
 import { YEAR_LIST } from './constant';
 
 describe('YEAR_LIST', () => {
-  it('첫 번째 항목이 "전체"이다', () => {
-    expect(YEAR_LIST[0]).toBe('전체');
-  });
-
   it('AWARD_LIST의 모든 연도를 포함한다', () => {
     const expectedYears = [
       ...new Set(AWARD_LIST.map((a) => Number(a.date.slice(0, 4)))),

--- a/src/features/award/model/useYearFilter.test.ts
+++ b/src/features/award/model/useYearFilter.test.ts
@@ -1,18 +1,12 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { YEAR_LIST } from './constant';
 import { useYearFilter } from './useYearFilter';
 
 describe('useYearFilter', () => {
   it('초기 activeYear는 "전체"이다', () => {
     const { result } = renderHook(() => useYearFilter());
     expect(result.current.activeYear).toBe('전체');
-  });
-
-  it('yearList는 YEAR_LIST와 동일하다', () => {
-    const { result } = renderHook(() => useYearFilter());
-    expect(result.current.yearList).toEqual(YEAR_LIST);
   });
 
   it('handleYearChange 호출 시 activeYear가 변경된다', () => {

--- a/src/features/award/ui/Pagination.test.tsx
+++ b/src/features/award/ui/Pagination.test.tsx
@@ -126,32 +126,4 @@ describe('Pagination', () => {
       expect(onPageChange).toHaveBeenCalledWith(0);
     });
   });
-
-  describe('React Compiler 메모이제이션 캐시 히트', () => {
-    it('currentPage 변경 시 활성 dot이 업데이트된다 (캐시 히트/미스 분기 커버)', () => {
-      const onPageChange = vi.fn();
-      const { rerender } = render(
-        <Pagination
-          currentPage={0}
-          totalPages={3}
-          onPageChange={onPageChange}
-        />,
-      );
-
-      rerender(
-        <Pagination
-          currentPage={1}
-          totalPages={3}
-          onPageChange={onPageChange}
-        />,
-      );
-
-      expect(
-        screen.getByRole('button', { name: 'Go to page 2' }),
-      ).toHaveAttribute('aria-current', 'page');
-      expect(
-        screen.getByRole('button', { name: 'Go to page 1' }),
-      ).not.toHaveAttribute('aria-current');
-    });
-  });
 });

--- a/src/features/award/ui/YearCategory.test.tsx
+++ b/src/features/award/ui/YearCategory.test.tsx
@@ -144,31 +144,4 @@ describe('YearCategory', () => {
       expect(onYearChange).toHaveBeenCalledWith('전체');
     });
   });
-
-  describe('React Compiler 메모이제이션 캐시 히트', () => {
-    it('props 변경 시 활성 연도가 업데이트된다 (캐시 히트/미스 분기 커버)', () => {
-      const onYearChange = vi.fn();
-      const { rerender } = render(
-        <YearCategory
-          yearList={yearList}
-          activeYear='전체'
-          onYearChange={onYearChange}
-        />,
-      );
-
-      rerender(
-        <YearCategory
-          yearList={yearList}
-          activeYear={2008}
-          onYearChange={onYearChange}
-        />,
-      );
-
-      expect(screen.getByText('2008')).toHaveAttribute('aria-selected', 'true');
-      expect(screen.getByText('전체')).toHaveAttribute(
-        'aria-selected',
-        'false',
-      );
-    });
-  });
 });

--- a/src/widgets/award/model/responsive.test.ts
+++ b/src/widgets/award/model/responsive.test.ts
@@ -1,16 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { BREAKPOINTS, getItemsPerPage } from './responsive';
-
-describe('BREAKPOINTS', () => {
-  it('mobile 브레이크포인트가 767이다', () => {
-    expect(BREAKPOINTS.mobile).toBe(767);
-  });
-
-  it('tablet 브레이크포인트가 1024이다', () => {
-    expect(BREAKPOINTS.tablet).toBe(1024);
-  });
-});
+import { getItemsPerPage } from './responsive';
 
 describe('getItemsPerPage', () => {
   beforeEach(() => {

--- a/src/widgets/award/model/useSlideGesture.test.ts
+++ b/src/widgets/award/model/useSlideGesture.test.ts
@@ -35,19 +35,6 @@ describe('useSlideGesture', () => {
     });
   });
 
-  describe('useEffect — null ref 분기', () => {
-    it('ref.current가 null이면 wheel 리스너가 등록되지 않는다 (early return 분기 커버)', () => {
-      // renderHook은 DOM 요소에 ref를 연결하지 않으므로 ref.current === null
-      const mockSetPage = vi.fn();
-      renderHook(() => useSlideGesture(mockSetPage, 3));
-
-      // wheel 이벤트를 발생시켜도 setPage가 호출되지 않는다
-      window.dispatchEvent(new WheelEvent('wheel', { deltaX: 100, deltaY: 0 }));
-
-      expect(mockSetPage).not.toHaveBeenCalled();
-    });
-  });
-
   describe('onTouchStart / onTouchEnd', () => {
     it('onTouchEnd: touchStartX가 null이면 아무것도 하지 않는다', () => {
       const mockSetPage = vi.fn();

--- a/src/widgets/award/ui/Award.test.tsx
+++ b/src/widgets/award/ui/Award.test.tsx
@@ -188,16 +188,4 @@ describe('Award', () => {
       expect(sliderAfter).not.toBe(sliderBefore);
     });
   });
-
-  describe('React Compiler 메모이제이션 캐시 히트', () => {
-    it('재렌더링 시에도 동일한 UI가 유지된다 (캐시 히트 분기 커버)', () => {
-      const { rerender } = render(<Award />);
-
-      rerender(<Award />);
-
-      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
-        'Award',
-      );
-    });
-  });
 });

--- a/src/widgets/award/ui/Popup.test.tsx
+++ b/src/widgets/award/ui/Popup.test.tsx
@@ -76,15 +76,4 @@ describe('AwardPopup', () => {
       expect(onClose).not.toHaveBeenCalled();
     });
   });
-
-  describe('React Compiler 메모이제이션 캐시 히트', () => {
-    it('재렌더링 시에도 동일한 UI가 유지된다 (캐시 히트 분기 커버)', () => {
-      const onClose = vi.fn();
-      const { rerender } = render(<AwardPopup awardId={1} onClose={onClose} />);
-
-      rerender(<AwardPopup awardId={1} onClose={onClose} />);
-
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-    });
-  });
 });

--- a/src/widgets/award/ui/Title.test.tsx
+++ b/src/widgets/award/ui/Title.test.tsx
@@ -20,14 +20,4 @@ describe('AwardTitle', () => {
     render(<AwardTitle />);
     expect(screen.getByText('수상 및 인증 내역')).toBeInTheDocument();
   });
-
-  it('재렌더링 시에도 동일한 UI가 유지된다 (React Compiler 캐시 히트 분기 커버)', () => {
-    const { rerender } = render(<AwardTitle />);
-
-    rerender(<AwardTitle />);
-
-    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
-      'Award',
-    );
-  });
 });

--- a/src/widgets/footer/ui/Footer.test.tsx
+++ b/src/widgets/footer/ui/Footer.test.tsx
@@ -97,17 +97,6 @@ describe('Footer', () => {
     });
   });
 
-  describe('React Compiler 메모이제이션 캐시 히트', () => {
-    it('재렌더링 시에도 동일한 UI가 유지된다 (캐시 히트 분기 커버)', () => {
-      const { rerender } = render(<Footer />);
-
-      rerender(<Footer />);
-
-      expect(screen.getByText(COMPANY.NAME_EN)).toBeInTheDocument();
-      expect(screen.getByText(COMPANY.NAME_KO)).toBeInTheDocument();
-    });
-  });
-
   describe('시맨틱 구조', () => {
     it('최상위 요소가 footer로 렌더링된다', () => {
       const { container } = render(<Footer />);
@@ -131,12 +120,6 @@ describe('Footer', () => {
       render(<Footer />);
 
       expect(screen.getByText('Address')).toBeInTheDocument();
-    });
-
-    it('address 요소가 3개 렌더링된다', () => {
-      const { container } = render(<Footer />);
-
-      expect(container.querySelectorAll('address')).toHaveLength(3);
     });
   });
 });

--- a/src/widgets/hero/ui/Hero.test.tsx
+++ b/src/widgets/hero/ui/Hero.test.tsx
@@ -50,19 +50,6 @@ describe('Hero', () => {
     });
   });
 
-  describe('React Compiler 메모이제이션 캐시 히트', () => {
-    it('재렌더링 시에도 동일한 UI가 유지된다 (캐시 히트 분기 커버)', () => {
-      const { rerender } = render(<Hero />);
-
-      rerender(<Hero />);
-
-      expect(screen.getByAltText('인들이앤에이치 로고')).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
-        `(주) ${COMPANY.NAME_KO}`,
-      );
-    });
-  });
-
   describe('시맨틱 구조', () => {
     it('최상위 요소가 section으로 렌더링된다', () => {
       const { container } = render(<Hero />);

--- a/src/widgets/hero/ui/HeroBackground.test.tsx
+++ b/src/widgets/hero/ui/HeroBackground.test.tsx
@@ -157,18 +157,6 @@ describe('HeroBackground', () => {
     });
   });
 
-  describe('React Compiler 메모이제이션 캐시 히트', () => {
-    it('재렌더링 시 canvas가 동일하게 유지된다 (캐시 히트 분기 커버)', () => {
-      const { container, rerender } = render(<HeroBackground />);
-
-      rerender(<HeroBackground />);
-
-      const canvas = container.querySelector('canvas');
-      expect(canvas).toBeInTheDocument();
-      expect(canvas).toHaveClass('hero__background');
-    });
-  });
-
   describe('Three.js 초기화 실패 시', () => {
     it('createScene에서 에러 발생 시 cleanup 함수가 호출되지 않는다', () => {
       mockCreateScene.mockImplementationOnce(() => {

--- a/src/widgets/map/model/transportInfo.test.ts
+++ b/src/widgets/map/model/transportInfo.test.ts
@@ -3,10 +3,6 @@ import { describe, expect, it } from 'vitest';
 import { TRANSPORT_ITEMS } from './transportInfo';
 
 describe('TRANSPORT_ITEMS', () => {
-  it('3개의 교통수단 항목을 포함한다', () => {
-    expect(TRANSPORT_ITEMS).toHaveLength(3);
-  });
-
   it('각 항목에 고유한 id가 있다', () => {
     const ids = TRANSPORT_ITEMS.map((item) => item.id);
     expect(new Set(ids).size).toBe(3);
@@ -16,29 +12,5 @@ describe('TRANSPORT_ITEMS', () => {
     TRANSPORT_ITEMS.forEach((item) => {
       expect(typeof item.Icon).toBe('function');
     });
-  });
-
-  it('도보 항목이 올바른 데이터를 가진다', () => {
-    const walk = TRANSPORT_ITEMS.find((item) => item.id === 'map__walk');
-    expect(walk).toBeDefined();
-    expect(walk!.label).toBe('도보');
-    expect(walk!.lines).toEqual([
-      '부산 남구 수영로 274-16',
-      '프렌즈 스크린 부산 대연점 옆 건물',
-    ]);
-  });
-
-  it('버스 항목이 올바른 데이터를 가진다', () => {
-    const bus = TRANSPORT_ITEMS.find((item) => item.id === 'map__bus');
-    expect(bus).toBeDefined();
-    expect(bus!.label).toBe('버스');
-    expect(bus!.lines).toEqual(['대연역 정거장', '경성대학교 정거장']);
-  });
-
-  it('지하철 항목이 올바른 데이터를 가진다', () => {
-    const subway = TRANSPORT_ITEMS.find((item) => item.id === 'map__subway');
-    expect(subway).toBeDefined();
-    expect(subway!.label).toBe('지하철');
-    expect(subway!.lines).toEqual(['2호선 경성대부경대역 5번 출구']);
   });
 });

--- a/src/widgets/map/ui/Map.test.tsx
+++ b/src/widgets/map/ui/Map.test.tsx
@@ -84,12 +84,6 @@ describe('Map', () => {
         screen.getByText('2호선 경성대부경대역 5번 출구'),
       ).toBeInTheDocument();
     });
-
-    it('3개의 li 항목이 렌더링된다', () => {
-      const { container } = render(<Map />);
-
-      expect(container.querySelectorAll('li')).toHaveLength(3);
-    });
   });
 
   describe('useEffect — makeMap 호출', () => {
@@ -113,18 +107,6 @@ describe('Map', () => {
       unmount();
 
       expect(mockCleanup).toHaveBeenCalledOnce();
-    });
-  });
-
-  describe('React Compiler 메모이제이션 캐시 히트', () => {
-    it('재렌더링 시에도 동일한 UI가 유지된다 (캐시 히트 분기 커버)', () => {
-      const { rerender } = render(<Map />);
-
-      rerender(<Map />);
-
-      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
-        'INDUEL E&H Address',
-      );
     });
   });
 });

--- a/src/widgets/patent/ui/Patent.test.tsx
+++ b/src/widgets/patent/ui/Patent.test.tsx
@@ -33,13 +33,6 @@ describe('Patent', () => {
       expect(screen.getByText('Patent')).toBeInTheDocument();
     });
 
-    it('유효 특허 건수가 표시된다', () => {
-      render(<Patent />);
-
-      // PATENT_IMG_DATA mock의 길이 = 5
-      expect(screen.getByText(/유효 특허 5건/)).toBeInTheDocument();
-    });
-
     it('권리 소멸 건수가 표시된다', () => {
       render(<Patent />);
 

--- a/src/widgets/vision/model/VisionData.test.ts
+++ b/src/widgets/vision/model/VisionData.test.ts
@@ -4,10 +4,6 @@ import { VISION_DATA } from './VisionData';
 
 describe('VISION_DATA', () => {
   describe('구조', () => {
-    it('3개의 항목을 포함한다', () => {
-      expect(VISION_DATA).toHaveLength(3);
-    });
-
     it('각 항목은 title, description, keyword, image 필드를 가진다', () => {
       VISION_DATA.forEach((item) => {
         expect(item).toHaveProperty('title');
@@ -21,26 +17,6 @@ describe('VISION_DATA', () => {
       VISION_DATA.forEach((item) => {
         expect(item.description.trim()).not.toBe('');
       });
-    });
-  });
-
-  describe('항목 값', () => {
-    it('첫 번째 항목은 Parametric Design이다', () => {
-      expect(VISION_DATA[0].title).toBe('Parametric Design');
-      expect(VISION_DATA[0].keyword).toBe('Param');
-      expect(VISION_DATA[0].image).toBe('vision_param.webp');
-    });
-
-    it('두 번째 항목은 Urban Sculpting이다', () => {
-      expect(VISION_DATA[1].title).toBe('Urban Sculpting');
-      expect(VISION_DATA[1].keyword).toBe('Sculpt');
-      expect(VISION_DATA[1].image).toBe('vision_sculpt.webp');
-    });
-
-    it('세 번째 항목은 Engineering Investment이다', () => {
-      expect(VISION_DATA[2].title).toBe('Engineering Investment');
-      expect(VISION_DATA[2].keyword).toBe('Invest');
-      expect(VISION_DATA[2].image).toBe('vision_invest.webp');
     });
   });
 });

--- a/src/widgets/vision/ui/SectionLayout.test.tsx
+++ b/src/widgets/vision/ui/SectionLayout.test.tsx
@@ -99,24 +99,4 @@ describe('SectionLayout', () => {
       );
     });
   });
-
-  describe('React Compiler 메모이제이션 캐시 히트', () => {
-    it('재렌더링 시에도 동일한 UI가 유지된다 (캐시 히트 분기 커버)', () => {
-      const { rerender, container } = render(
-        <SectionLayout
-          content={<div>content</div>}
-          keyword={<h1>keyword</h1>}
-        />,
-      );
-
-      rerender(
-        <SectionLayout
-          content={<div>content</div>}
-          keyword={<h1>keyword</h1>}
-        />,
-      );
-
-      expect(container.querySelector('section')).toHaveClass('vision__section');
-    });
-  });
 });

--- a/src/widgets/vision/ui/Vision.test.tsx
+++ b/src/widgets/vision/ui/Vision.test.tsx
@@ -99,16 +99,4 @@ describe('Vision', () => {
       expect(innerSections[2]).not.toHaveClass('vision__section-reverse');
     });
   });
-
-  describe('React Compiler 메모이제이션 캐시 히트', () => {
-    it('재렌더링 시에도 동일한 UI가 유지된다 (캐시 히트 분기 커버)', () => {
-      const { rerender } = render(<Vision />);
-
-      rerender(<Vision />);
-
-      expect(screen.getByText('Parametric Design')).toBeInTheDocument();
-      expect(screen.getByText('Urban Sculpting')).toBeInTheDocument();
-      expect(screen.getByText('Engineering Investment')).toBeInTheDocument();
-    });
-  });
 });

--- a/src/widgets/vision/ui/VisionItem.test.tsx
+++ b/src/widgets/vision/ui/VisionItem.test.tsx
@@ -75,19 +75,4 @@ describe('VisionItem', () => {
       ).toBeInTheDocument();
     });
   });
-
-  describe('React Compiler 메모이제이션 캐시 히트', () => {
-    it('재렌더링 시에도 동일한 UI가 유지된다 (캐시 히트 분기 커버)', () => {
-      const { rerender } = render(<VisionItem {...defaultProps} />);
-
-      rerender(<VisionItem {...defaultProps} />);
-
-      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
-        'Parametric Design',
-      );
-      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
-        'Param',
-      );
-    });
-  });
 });


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

해당 없음 (테스트 코드 품질 개선)

### 불필요 테스트 제거 배경

Coverage 100% 달성 목표로 작성된 테스트 중 실질적 의미 없이 억지로 작성된 테스트들을 제거합니다.

### 핵심 변화

#### 변경 전

- React Compiler memoization 효과를 검증하는 테스트 (리렌더링 횟수, `rerender` 후 동일 UI 확인 등)
- TypeScript 타입 시스템이 이미 보장하는 내용을 중복 검증하는 테스트 (`typeof item.year === 'number'` 등)
- 하드코딩된 데이터 개수/값을 검증하는 테스트 (`3개`, `8개`, `유효 특허 5건` 등)
- 구현 세부사항(커버리지용)만 검증하는 테스트 (null ref 분기, hook 내부 상수 참조 등)

#### 변경 후

- 실제 동작과 사용자 관점의 동작을 검증하는 테스트만 유지
- 데이터 변경 시 테스트도 함께 수정해야 하는 brittle 테스트 제거
- 22개 파일, 326줄 삭제

# 📋 작업 내용

- React Compiler 자동 최적화 관련 테스트 제거: Pagination, YearCategory, Award, Popup, Title, Footer, Hero, HeroBackground, Map, SectionLayout, Vision, VisionItem
- TypeScript 타입 중복 검증 테스트 제거: artworkData(3건), awardHistoryData(1건)
- 하드코딩 데이터 값/개수 테스트 제거: awardList, constant, transportInfo, Map, VisionData, Patent
- 커버리지 전용 구현 세부사항 테스트 제거: useSlideGesture null ref 분기, useYearFilter 상수 참조
- 미사용 import 정리: YEAR_LIST, BREAKPOINTS