### PR TITLE
✨ feat: Map 페이지 반응형 구현 및 디자인 개선

### DIFF
--- a/src/app/styles/index.css
+++ b/src/app/styles/index.css
@@ -76,6 +76,7 @@
 * {
   font-family: Pretendard, sans-serif;
   font-variant-numeric: tabular-nums;
+  font-style: normal;
   line-height: 1.4;
   margin: 0;
   padding: 0;

--- a/src/entities/map/model/transportInfo.ts
+++ b/src/entities/map/model/transportInfo.ts
@@ -1,5 +1,5 @@
 import type { IconType } from 'react-icons';
-import { FaMapMarkedAlt } from 'react-icons/fa';
+import { FaMapMarkerAlt } from 'react-icons/fa';
 import { MdDirectionsBus, MdSubway } from 'react-icons/md';
 
 export type TransportItem = {
@@ -12,20 +12,23 @@ export type TransportItem = {
 export const TRANSPORT_ITEMS: TransportItem[] = [
   {
     id: 'map__walk',
-    Icon: FaMapMarkedAlt,
+    Icon: FaMapMarkerAlt,
     label: '도보',
-    lines: ['부산 남구 수영로 274-16', '프렌즈 스크린 부산 대연점 옆 건물'],
+    lines: [
+      '부산 남구 수영로 274-16 (우) 48498',
+      '프렌즈 스크린 부산 대연점 옆 건물',
+    ],
   },
   {
     id: 'map__bus',
     Icon: MdDirectionsBus,
     label: '버스',
-    lines: ['대연역 정거장', '경성대학교 정거장'],
+    lines: ['대연역 정거장 (211m)', '경성대학교 정거장 (278m)'],
   },
   {
     id: 'map__subway',
     Icon: MdSubway,
     label: '지하철',
-    lines: ['2호선 경성대부경대역 5번 출구'],
+    lines: ['2호선 경성대부경대역 5번 출구 (348m)'],
   },
 ];

--- a/src/entities/map/model/transportInfo.ts
+++ b/src/entities/map/model/transportInfo.ts
@@ -1,6 +1,6 @@
 import type { IconType } from 'react-icons';
+import { FaMapMarkedAlt } from 'react-icons/fa';
 import { MdDirectionsBus, MdSubway } from 'react-icons/md';
-import { TbWalk } from 'react-icons/tb';
 
 export type TransportItem = {
   id: string;
@@ -12,7 +12,7 @@ export type TransportItem = {
 export const TRANSPORT_ITEMS: TransportItem[] = [
   {
     id: 'map__walk',
-    Icon: TbWalk,
+    Icon: FaMapMarkedAlt,
     label: '도보',
     lines: ['부산 남구 수영로 274-16', '프렌즈 스크린 부산 대연점 옆 건물'],
   },

--- a/src/widgets/map/model/map.test.ts
+++ b/src/widgets/map/model/map.test.ts
@@ -66,21 +66,9 @@ describe('map', () => {
   });
 
   describe('getZoom (makeMap을 통해 간접 검증)', () => {
-    it('physicalWidth < 3840이면 zoom 15로 지도가 생성된다', () => {
+    it('physicalWidth < 7680이면 zoom 17로 지도가 생성된다', () => {
       vi.stubGlobal('screen', { width: 1920 });
       vi.stubGlobal('devicePixelRatio', 1); // 1920 * 1 = 1920
-
-      lastCleanup = makeMap(mockEl);
-
-      expect(MockNaverMap).toHaveBeenCalledWith(
-        mockEl,
-        expect.objectContaining({ zoom: 15 }),
-      );
-    });
-
-    it('physicalWidth === 3840이면 zoom 17로 지도가 생성된다', () => {
-      vi.stubGlobal('screen', { width: 3840 });
-      vi.stubGlobal('devicePixelRatio', 1); // 3840 * 1 = 3840
 
       lastCleanup = makeMap(mockEl);
 
@@ -90,9 +78,21 @@ describe('map', () => {
       );
     });
 
-    it('physicalWidth === 7680이면 zoom 20으로 지도가 생성된다', () => {
+    it('physicalWidth >= 7680이면 zoom 20으로 지도가 생성된다', () => {
       vi.stubGlobal('screen', { width: 7680 });
       vi.stubGlobal('devicePixelRatio', 1); // 7680 * 1 = 7680
+
+      lastCleanup = makeMap(mockEl);
+
+      expect(MockNaverMap).toHaveBeenCalledWith(
+        mockEl,
+        expect.objectContaining({ zoom: 20 }),
+      );
+    });
+
+    it('devicePixelRatio 2에서 physicalWidth >= 7680이면 zoom 20으로 지도가 생성된다', () => {
+      vi.stubGlobal('screen', { width: 3840 });
+      vi.stubGlobal('devicePixelRatio', 2); // 3840 * 2 = 7680
 
       lastCleanup = makeMap(mockEl);
 

--- a/src/widgets/map/model/map.test.ts
+++ b/src/widgets/map/model/map.test.ts
@@ -119,6 +119,19 @@ describe('map', () => {
       );
     });
 
+    it('zoomControlOptions에 TOP_RIGHT position이 설정된다', () => {
+      lastCleanup = makeMap(mockEl);
+
+      expect(MockNaverMap).toHaveBeenCalledWith(
+        mockEl,
+        expect.objectContaining({
+          zoomControlOptions: expect.objectContaining({
+            position: 'TOP_RIGHT',
+          }) as unknown,
+        }),
+      );
+    });
+
     it('makeMapMarker가 생성된 지도로 호출된다', () => {
       lastCleanup = makeMap(mockEl);
 

--- a/src/widgets/map/model/map.ts
+++ b/src/widgets/map/model/map.ts
@@ -4,8 +4,7 @@ import { makeMapMarker, updateMarkerIcon } from './mapMarker';
 function getZoom(): number {
   const physicalWidth = window.screen.width * window.devicePixelRatio;
   if (physicalWidth >= 7680) return 20;
-  if (physicalWidth >= 3840) return 17;
-  return 15;
+  return 17;
 }
 
 export function makeMap(el: HTMLDivElement): () => void {

--- a/src/widgets/map/model/mapInfoCard.test.ts
+++ b/src/widgets/map/model/mapInfoCard.test.ts
@@ -64,12 +64,12 @@ describe('mapInfoCard', () => {
       expect(content).toContain(COMPANY.NAME_KO);
     });
 
-    it('InfoWindow content에 회사 영문 약칭이 포함된다', () => {
+    it('InfoWindow content에 회사 영문 전체 명칭이 포함된다', () => {
       makeInfoCard(mockMap, mockMarker);
 
       const content = (MockInfoWindow.mock.calls[0][0] as { content: string })
         .content;
-      expect(content).toContain(COMPANY.NAME_EN);
+      expect(content).toContain('INDUEL ENGINEERING & HOLDINGS');
     });
 
     it('InfoWindow content에 전화번호 tel: 링크가 포함된다', () => {

--- a/src/widgets/map/model/mapInfoCard.test.ts
+++ b/src/widgets/map/model/mapInfoCard.test.ts
@@ -107,6 +107,22 @@ describe('mapInfoCard', () => {
         expect.objectContaining({ borderWidth: 0 }),
       );
     });
+
+    it('InfoWindow에 disableAnchor: true가 설정된다', () => {
+      makeInfoCard(mockMap, mockMarker);
+
+      expect(MockInfoWindow).toHaveBeenCalledWith(
+        expect.objectContaining({ disableAnchor: true }),
+      );
+    });
+
+    it('InfoWindow에 backgroundColor가 transparent로 설정된다', () => {
+      makeInfoCard(mockMap, mockMarker);
+
+      expect(MockInfoWindow).toHaveBeenCalledWith(
+        expect.objectContaining({ backgroundColor: 'transparent' }),
+      );
+    });
   });
 
   describe('click 핸들러 토글', () => {

--- a/src/widgets/map/model/mapInfoCard.ts
+++ b/src/widgets/map/model/mapInfoCard.ts
@@ -16,7 +16,7 @@ const INFO_CONTENT = `
       </svg>
       <div>
         <p class="map__info__name">${COMPANY.NAME_KO}</p>
-        <p class="map__info__subtitle">${COMPANY.NAME_EN}</p>
+        <p class="map__info__subtitle">INDUEL ENGINEERING & HOLDINGS</p>
       </div>
     </div>
     <div class="map__info__body">

--- a/src/widgets/map/model/mapMarker.test.ts
+++ b/src/widgets/map/model/mapMarker.test.ts
@@ -78,6 +78,13 @@ describe('mapMarker', () => {
         }),
       );
     });
+
+    it('마커 SVG content에 map__marker 클래스가 포함된다', () => {
+      makeMapMarker(mockMap as unknown as naver.maps.Map);
+
+      const call = MockMarker.mock.calls[0][0] as { icon: { content: string } };
+      expect(call.icon.content).toContain('map__marker');
+    });
   });
 
   describe('updateMarkerIcon', () => {
@@ -102,6 +109,13 @@ describe('mapMarker', () => {
 
       expect(MockSize).toHaveBeenCalledOnce();
       expect(MockPoint).toHaveBeenCalledOnce();
+    });
+
+    it('setIcon에 전달된 content가 map__marker SVG를 포함한다', () => {
+      updateMarkerIcon(mockMarker as unknown as naver.maps.Marker);
+
+      const icon = mockSetIcon.mock.calls[0][0] as { content: string };
+      expect(icon.content).toContain('map__marker');
     });
   });
 });

--- a/src/widgets/map/styles/Map.css
+++ b/src/widgets/map/styles/Map.css
@@ -288,3 +288,110 @@
     font-size: 2.08vmin;
   }
 }
+
+@media (max-width: 767px) {
+  .map {
+    height: 100vh;
+    align-items: center;
+    gap: 5.33vmin;
+    padding: 16vmin 4vmin 4vmin 4vmin;
+  }
+
+  .map__title {
+    gap: 2.67vmin;
+  }
+
+  .map__title_text p {
+    font-size: 3.2vmin;
+  }
+
+  .map__title_text h2 {
+    font-size: 8vmin;
+  }
+
+  .map__title hr {
+    width: 16vmin;
+    border-top: 0.93vmin solid var(--brown-800);
+  }
+
+  .map__card {
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    border-radius: 5.3vmin;
+    box-shadow: 0 0 2.13vmin rgba(0, 0, 0, 0.25);
+  }
+
+  .map__content {
+    width: 100%;
+    height: 45.74%;
+  }
+
+  .map__card_content {
+    width: 100%;
+    height: 54.26%;
+    padding: 4vmin 8vmin;
+  }
+
+  .map__card_content h3 {
+    font-size: 4.27vmin;
+  }
+
+  .map__description {
+    gap: 2.67vmin;
+  }
+
+  .map__description li {
+    gap: 2.67vmin;
+  }
+
+  .map__icon_frame {
+    width: 8vmin;
+    height: 8vmin;
+  }
+
+  .map__icon {
+    width: 4vmin;
+    height: 4vmin;
+  }
+
+  .map__description_text {
+    gap: 0;
+  }
+
+  .map__description_text h4 {
+    font-size: 3.2vmin;
+  }
+
+  .map__description__content p {
+    font-size: 2.67vmin;
+  }
+
+  .map__card_content hr {
+    border-top: 0.27vmin solid var(--brown-200);
+  }
+
+  .map__description_call {
+    gap: 2.67vmin;
+    padding: 2.67vmin 0;
+    border-radius: 1.87vmin;
+    box-shadow: 0 1.07vmin 1.07vmin rgb(0, 0, 0, 0.25);
+  }
+
+  .map__description_call:hover {
+    box-shadow: 0 0.78vmin 0.42vmin rgba(0, 0, 0, 0.35);
+  }
+
+  .map__description_call svg {
+    width: 4vmin;
+    height: 4vmin;
+  }
+
+  .map__description_call_text {
+    gap: 1.33vmin;
+  }
+
+  .map__description_call_text span {
+    font-size: 3.2vmin;
+  }
+}

--- a/src/widgets/map/styles/Map.css
+++ b/src/widgets/map/styles/Map.css
@@ -24,13 +24,6 @@
   text-shadow: 0 4px 4px #00000040;
 }
 
-.map__title hr {
-  width: 31.25%;
-  height: 0.05vh;
-  background-color: var(--gray-700);
-  border-radius: 999px;
-}
-
 .map__wrapper {
   position: relative;
   width: 100%;

--- a/src/widgets/map/styles/Map.css
+++ b/src/widgets/map/styles/Map.css
@@ -2,85 +2,165 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100vh;
-  background-color: var(--white);
+  height: 85.11vh;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3.125vmax 0 2.34vmax 0;
   overflow: hidden;
+  background-color: #faf9f8;
 }
 
 .map__title {
   display: flex;
-  width: 100%;
-  height: 11vh;
-  padding: 1.04% 2.6%;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
+  gap: 0.78vmax;
 }
 
-.map__title h2 {
-  color: var(--footer-background);
-  font-size: 3.125vmax;
-  white-space: nowrap;
-  font-weight: 900;
-  text-shadow: 0 4px 4px #00000040;
+.map__title_text {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
-.map__wrapper {
-  position: relative;
-  width: 100%;
-  height: 100%;
+.map__title_text p {
+  font-weight: 700;
+  font-size: 0.78vmax;
+  letter-spacing: 0.05em;
+  color: var(--brown-800);
+}
+
+.map__title_text h2 {
+  font-weight: 700;
+  font-size: 2.34vmax;
+  letter-spacing: 0.025em;
+  color: var(--typo-titleB);
+}
+
+.map__title hr {
+  width: 3.65vmax;
+  border: none;
+  border-top: 3.5px solid var(--brown-800);
+}
+
+.map__card {
+  display: flex;
+  flex-direction: row;
+  width: 70.83vmax;
+  height: 27.6vmax;
+  gap: 0;
+  border-radius: 20px;
+  background-color: var(--white);
+  box-shadow: 0 0 0.42vmax rgba(0, 0, 0, 0.25);
 }
 
 .map__content {
-  width: 100%;
+  width: 66.18%;
   height: 100%;
 }
 
-.map__description {
-  color: var(--typo-titleB);
-  padding: 2.625% 2.625%;
+.map__card_content {
+  display: flex;
+  flex-direction: column;
+  width: 33.82%;
+  height: 100%;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 2.6vmax 3.65vmax;
 }
 
-.map__description ul {
+.map__card_content h3 {
+  font-weight: 700;
+  font-size: 1.3vmax;
+  color: var(--brown-800);
+}
+
+.map__description {
   display: flex;
-  flex-direction: row;
-  gap: 10.4167%;
-  list-style: none;
-  justify-content: center;
+  flex-direction: column;
   align-items: flex-start;
+  gap: 1.56vmax;
 }
 
 .map__description li {
   display: flex;
-  flex-direction: column;
-  font-size: 1.3vmax;
+  flex-direction: row;
+  justify-content: flex-start;
   gap: 0.78vmax;
 }
 
-.map__description_title {
+.map__icon_frame {
   display: flex;
-  flex-direction: row;
   align-items: center;
-  gap: 0.52vmax;
-}
-
-.map__description_title h3 {
-  font-size: 1.56vmax;
-  font-weight: 600;
+  justify-content: center;
+  width: 1.93vmax;
+  height: 1.93vmax;
+  border-radius: 50%;
+  background-color: #e4ddd7;
 }
 
 .map__icon {
-  width: 2.19vmax;
-  height: 2.19vmax;
+  width: 0.99vmax;
+  aspect-ratio: 1/1;
+  color: var(--brown-800);
 }
 
-#map__walk {
-  color: #ff00aa;
+.map__description_text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.26vmax;
 }
 
-#map__bus {
-  color: #0d99ff;
+.map__description_text h4 {
+  font-weight: 700;
+  font-size: 0.73vmax;
+  color: var(--brown-900);
 }
 
-#map__subway {
-  color: #81bf48;
+.map__description__content {
+  display: flex;
+  flex-direction: column;
+}
+
+.map__description__content p {
+  font-weight: 500;
+  font-size: 0.63vmax;
+  color: var(--brown-800);
+}
+
+.map__card_content hr {
+  width: 100%;
+  border: none;
+  border-top: 1px solid var(--brown-200);
+}
+
+.map__description_call {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 0.52vmax;
+  padding: 0.78vmax 0;
+  border-radius: 7px;
+  background-color: var(--brown-800);
+  box-shadow: 0 0.21vmax 0.21vmax rgba(0, 0, 0, 0.25);
+}
+
+.map__description_call svg {
+  width: 0.94vmax;
+  height: 0.94vmax;
+}
+
+.map__description_call_text {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  gap: 0.26vmax;
+}
+
+.map__description_call_text span {
+  font-weight: 700;
+  font-size: 0.83vmax;
+  color: var(--white);
 }

--- a/src/widgets/map/styles/Map.css
+++ b/src/widgets/map/styles/Map.css
@@ -145,11 +145,28 @@
   border-radius: 7px;
   background-color: var(--brown-800);
   box-shadow: 0 0.21vmax 0.21vmax rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.map__description_call:hover {
+  background-color: var(--brown-900);
+  box-shadow: 0 0.31vmax 0.42vmax rgba(0, 0, 0, 0.35);
+}
+
+.map__description_call:active {
+  background-color: var(--brown-900);
+  box-shadow: none;
+  transform: translateY(1px);
 }
 
 .map__description_call svg {
   width: 0.94vmax;
   height: 0.94vmax;
+  color: var(--white);
 }
 
 .map__description_call_text {

--- a/src/widgets/map/styles/Map.css
+++ b/src/widgets/map/styles/Map.css
@@ -40,7 +40,7 @@
 .map__title hr {
   width: 3.65vmax;
   border: none;
-  border-top: 3.5px solid var(--brown-800);
+  border-top: 0.18vmax solid var(--brown-800);
 }
 
 .map__card {
@@ -49,7 +49,7 @@
   width: 70.83vmax;
   height: 27.6vmax;
   gap: 0;
-  border-radius: 20px;
+  border-radius: 1.04vmax;
   background-color: var(--white);
   box-shadow: 0 0 0.42vmax rgba(0, 0, 0, 0.25);
 }
@@ -131,7 +131,7 @@
 .map__card_content hr {
   width: 100%;
   border: none;
-  border-top: 1px solid var(--brown-200);
+  border-top: 0.05vmax solid var(--brown-200);
 }
 
 .map__description_call {
@@ -142,7 +142,7 @@
   justify-content: center;
   gap: 0.52vmax;
   padding: 0.78vmax 0;
-  border-radius: 7px;
+  border-radius: 0.36vmax;
   background-color: var(--brown-800);
   box-shadow: 0 0.21vmax 0.21vmax rgba(0, 0, 0, 0.25);
   cursor: pointer;

--- a/src/widgets/map/styles/Map.css
+++ b/src/widgets/map/styles/Map.css
@@ -100,8 +100,8 @@
 }
 
 .map__icon {
-  width: 0.99vmax;
-  aspect-ratio: 1/1;
+  width: 1.13vmax;
+  height: 1.13vmax;
   color: var(--brown-800);
 }
 
@@ -180,4 +180,111 @@
   font-weight: 700;
   font-size: 0.83vmax;
   color: var(--white);
+}
+
+@media (max-width: 1024px) {
+  .map {
+    height: 100vh;
+    align-items: center;
+    gap: 3.91vmin;
+    padding: 7.81vmin 3.91vmin 5.86vmin 3.91vmin;
+  }
+
+  .map__title {
+    gap: 1.95vmin;
+  }
+
+  .map__title_text p {
+    font-size: 1.95vmin;
+  }
+
+  .map__title_text h2 {
+    font-size: 5.86vmin;
+  }
+
+  .map__title hr {
+    width: 9.11vmin;
+    border-top: 0.46vmin solid var(--brown-800);
+  }
+
+  .map__card {
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    border-radius: 2.6vmin;
+    box-shadow: 0 0 1.04vmin rgba(0, 0, 0, 0.25);
+  }
+
+  .map__content {
+    width: 100%;
+    height: 50%;
+  }
+
+  .map__card_content {
+    width: 100%;
+    height: 50%;
+    padding: 2.6vmin 9.11vmin;
+  }
+
+  .map__card_content h3 {
+    font-size: 2.6vmin;
+  }
+
+  .map__description {
+    gap: 1.95vmin;
+  }
+
+  .map__description li {
+    gap: 1.95vmin;
+  }
+
+  .map__icon_frame {
+    width: 4.3vmin;
+    height: 4.3vmin;
+  }
+
+  .map__icon {
+    width: 2.66vmin;
+    height: 2.66vmin;
+  }
+
+  .map__description_text {
+    gap: 0.65vmin;
+  }
+
+  .map__description_text h4 {
+    font-size: 1.56vmin;
+  }
+
+  .map__description__content p {
+    font-size: 1.3vmin;
+  }
+
+  .map__card_content hr {
+    border-top: 0.13vmin solid var(--brown-200);
+  }
+
+  .map__description_call {
+    gap: 1.3vmin;
+    padding: 1.95vmin 0;
+    border-radius: 0.91vmin;
+    box-shadow: 0 0.52vmin 0.52vmin rgb(0, 0, 0, 0.25);
+  }
+
+  .map__description_call:hover {
+    box-shadow: 0 0.78vmin 0.42vmin rgba(0, 0, 0, 0.35);
+  }
+
+  .map__description_call svg {
+    width: 2.34vmin;
+    height: 2.34vmin;
+  }
+
+  .map__description_call_text {
+    gap: 0.65vmin;
+  }
+
+  .map__description_call_text span {
+    font-size: 2.08vmin;
+  }
 }

--- a/src/widgets/map/styles/Map.css
+++ b/src/widgets/map/styles/Map.css
@@ -10,39 +10,6 @@
   background-color: #faf9f8;
 }
 
-.map__title {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.78vmax;
-}
-
-.map__title_text {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.map__title_text p {
-  font-weight: 700;
-  font-size: 0.78vmax;
-  letter-spacing: 0.05em;
-  color: var(--brown-800);
-}
-
-.map__title_text h2 {
-  font-weight: 700;
-  font-size: 2.34vmax;
-  letter-spacing: 0.025em;
-  color: var(--typo-titleB);
-}
-
-.map__title hr {
-  width: 3.65vmax;
-  border: none;
-  border-top: 0.18vmax solid var(--brown-800);
-}
-
 .map__card {
   display: flex;
   flex-direction: row;
@@ -54,134 +21,6 @@
   box-shadow: 0 0 0.42vmax rgba(0, 0, 0, 0.25);
 }
 
-.map__content {
-  width: 66.18%;
-  height: 100%;
-}
-
-.map__card_content {
-  display: flex;
-  flex-direction: column;
-  width: 33.82%;
-  height: 100%;
-  align-items: flex-start;
-  justify-content: space-between;
-  padding: 2.6vmax 3.65vmax;
-}
-
-.map__card_content h3 {
-  font-weight: 700;
-  font-size: 1.3vmax;
-  color: var(--brown-800);
-}
-
-.map__description {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 1.56vmax;
-}
-
-.map__description li {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  gap: 0.78vmax;
-}
-
-.map__icon_frame {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.93vmax;
-  height: 1.93vmax;
-  border-radius: 50%;
-  background-color: #e4ddd7;
-}
-
-.map__icon {
-  width: 1.13vmax;
-  height: 1.13vmax;
-  color: var(--brown-800);
-}
-
-.map__description_text {
-  display: flex;
-  flex-direction: column;
-  gap: 0.26vmax;
-}
-
-.map__description_text h4 {
-  font-weight: 700;
-  font-size: 0.73vmax;
-  color: var(--brown-900);
-}
-
-.map__description__content {
-  display: flex;
-  flex-direction: column;
-}
-
-.map__description__content p {
-  font-weight: 500;
-  font-size: 0.63vmax;
-  color: var(--brown-800);
-}
-
-.map__card_content hr {
-  width: 100%;
-  border: none;
-  border-top: 0.05vmax solid var(--brown-200);
-}
-
-.map__description_call {
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-  align-items: center;
-  justify-content: center;
-  gap: 0.52vmax;
-  padding: 0.78vmax 0;
-  border-radius: 0.36vmax;
-  background-color: var(--brown-800);
-  box-shadow: 0 0.21vmax 0.21vmax rgba(0, 0, 0, 0.25);
-  cursor: pointer;
-  text-decoration: none;
-  transition:
-    background-color 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.map__description_call:hover {
-  background-color: var(--brown-900);
-  box-shadow: 0 0.31vmax 0.42vmax rgba(0, 0, 0, 0.35);
-}
-
-.map__description_call:active {
-  background-color: var(--brown-900);
-  box-shadow: none;
-  transform: translateY(1px);
-}
-
-.map__description_call svg {
-  width: 0.94vmax;
-  height: 0.94vmax;
-  color: var(--white);
-}
-
-.map__description_call_text {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  gap: 0.26vmax;
-}
-
-.map__description_call_text span {
-  font-weight: 700;
-  font-size: 0.83vmax;
-  color: var(--white);
-}
-
 @media (max-width: 1024px) {
   .map {
     height: 100vh;
@@ -190,102 +29,12 @@
     padding: 7.81vmin 3.91vmin 5.86vmin 3.91vmin;
   }
 
-  .map__title {
-    gap: 1.95vmin;
-  }
-
-  .map__title_text p {
-    font-size: 1.95vmin;
-  }
-
-  .map__title_text h2 {
-    font-size: 5.86vmin;
-  }
-
-  .map__title hr {
-    width: 9.11vmin;
-    border-top: 0.46vmin solid var(--brown-800);
-  }
-
   .map__card {
     flex-direction: column;
     width: 100%;
     height: 100%;
     border-radius: 2.6vmin;
     box-shadow: 0 0 1.04vmin rgba(0, 0, 0, 0.25);
-  }
-
-  .map__content {
-    width: 100%;
-    height: 50%;
-  }
-
-  .map__card_content {
-    width: 100%;
-    height: 50%;
-    padding: 2.6vmin 9.11vmin;
-  }
-
-  .map__card_content h3 {
-    font-size: 2.6vmin;
-  }
-
-  .map__description {
-    gap: 1.95vmin;
-  }
-
-  .map__description li {
-    gap: 1.95vmin;
-  }
-
-  .map__icon_frame {
-    width: 4.3vmin;
-    height: 4.3vmin;
-  }
-
-  .map__icon {
-    width: 2.66vmin;
-    height: 2.66vmin;
-  }
-
-  .map__description_text {
-    gap: 0.65vmin;
-  }
-
-  .map__description_text h4 {
-    font-size: 1.56vmin;
-  }
-
-  .map__description__content p {
-    font-size: 1.3vmin;
-  }
-
-  .map__card_content hr {
-    border-top: 0.13vmin solid var(--brown-200);
-  }
-
-  .map__description_call {
-    gap: 1.3vmin;
-    padding: 1.95vmin 0;
-    border-radius: 0.91vmin;
-    box-shadow: 0 0.52vmin 0.52vmin rgb(0, 0, 0, 0.25);
-  }
-
-  .map__description_call:hover {
-    box-shadow: 0 0.78vmin 0.42vmin rgba(0, 0, 0, 0.35);
-  }
-
-  .map__description_call svg {
-    width: 2.34vmin;
-    height: 2.34vmin;
-  }
-
-  .map__description_call_text {
-    gap: 0.65vmin;
-  }
-
-  .map__description_call_text span {
-    font-size: 2.08vmin;
   }
 }
 
@@ -297,101 +46,11 @@
     padding: 16vmin 4vmin 4vmin 4vmin;
   }
 
-  .map__title {
-    gap: 2.67vmin;
-  }
-
-  .map__title_text p {
-    font-size: 3.2vmin;
-  }
-
-  .map__title_text h2 {
-    font-size: 8vmin;
-  }
-
-  .map__title hr {
-    width: 16vmin;
-    border-top: 0.93vmin solid var(--brown-800);
-  }
-
   .map__card {
     flex-direction: column;
     width: 100%;
     height: 100%;
     border-radius: 5.3vmin;
     box-shadow: 0 0 2.13vmin rgba(0, 0, 0, 0.25);
-  }
-
-  .map__content {
-    width: 100%;
-    height: 45.74%;
-  }
-
-  .map__card_content {
-    width: 100%;
-    height: 54.26%;
-    padding: 4vmin 8vmin;
-  }
-
-  .map__card_content h3 {
-    font-size: 4.27vmin;
-  }
-
-  .map__description {
-    gap: 2.67vmin;
-  }
-
-  .map__description li {
-    gap: 2.67vmin;
-  }
-
-  .map__icon_frame {
-    width: 8vmin;
-    height: 8vmin;
-  }
-
-  .map__icon {
-    width: 4vmin;
-    height: 4vmin;
-  }
-
-  .map__description_text {
-    gap: 0;
-  }
-
-  .map__description_text h4 {
-    font-size: 3.2vmin;
-  }
-
-  .map__description__content p {
-    font-size: 2.67vmin;
-  }
-
-  .map__card_content hr {
-    border-top: 0.27vmin solid var(--brown-200);
-  }
-
-  .map__description_call {
-    gap: 2.67vmin;
-    padding: 2.67vmin 0;
-    border-radius: 1.87vmin;
-    box-shadow: 0 1.07vmin 1.07vmin rgb(0, 0, 0, 0.25);
-  }
-
-  .map__description_call:hover {
-    box-shadow: 0 0.78vmin 0.42vmin rgba(0, 0, 0, 0.35);
-  }
-
-  .map__description_call svg {
-    width: 4vmin;
-    height: 4vmin;
-  }
-
-  .map__description_call_text {
-    gap: 1.33vmin;
-  }
-
-  .map__description_call_text span {
-    font-size: 3.2vmin;
   }
 }

--- a/src/widgets/map/styles/Map.css
+++ b/src/widgets/map/styles/Map.css
@@ -4,8 +4,8 @@
   width: 100%;
   height: 85.11vh;
   align-items: center;
-  justify-content: space-between;
-  padding: 3.125vmax 0 2.34vmax 0;
+  gap: 3.125vmax;
+  padding: 3.125vmax 14.58vmax 2.34vmax 14.58vmax;
   overflow: hidden;
   background-color: #faf9f8;
 }
@@ -46,8 +46,8 @@
 .map__card {
   display: flex;
   flex-direction: row;
-  width: 70.83vmax;
-  height: 27.6vmax;
+  width: 100%;
+  height: 100%;
   gap: 0;
   border-radius: 1.04vmax;
   background-color: var(--white);

--- a/src/widgets/map/styles/MapCard.css
+++ b/src/widgets/map/styles/MapCard.css
@@ -1,0 +1,277 @@
+.map__content {
+  width: 66.18%;
+  height: 100%;
+}
+
+.map__card_content {
+  display: flex;
+  flex-direction: column;
+  width: 33.82%;
+  height: 100%;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 2.6vmax 3.65vmax;
+}
+
+.map__card_content h3 {
+  font-weight: 700;
+  font-size: 1.3vmax;
+  color: var(--brown-800);
+}
+
+.map__description {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.56vmax;
+}
+
+.map__description li {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  gap: 0.78vmax;
+}
+
+.map__icon_frame {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.93vmax;
+  height: 1.93vmax;
+  border-radius: 50%;
+  background-color: #e4ddd7;
+}
+
+.map__icon {
+  width: 1.13vmax;
+  height: 1.13vmax;
+  color: var(--brown-800);
+}
+
+.map__description_text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.26vmax;
+}
+
+.map__description_text h4 {
+  font-weight: 700;
+  font-size: 0.73vmax;
+  color: var(--brown-900);
+}
+
+.map__description__content {
+  display: flex;
+  flex-direction: column;
+}
+
+.map__description__content p {
+  font-weight: 500;
+  font-size: 0.63vmax;
+  color: var(--brown-800);
+}
+
+.map__card_content hr {
+  width: 100%;
+  border: none;
+  border-top: 0.05vmax solid var(--brown-200);
+}
+
+.map__description_call {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 0.52vmax;
+  padding: 0.78vmax 0;
+  border-radius: 0.36vmax;
+  background-color: var(--brown-800);
+  box-shadow: 0 0.21vmax 0.21vmax rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.map__description_call:hover {
+  background-color: var(--brown-900);
+  box-shadow: 0 0.31vmax 0.42vmax rgba(0, 0, 0, 0.35);
+}
+
+.map__description_call:active {
+  background-color: var(--brown-900);
+  box-shadow: none;
+  transform: translateY(1px);
+}
+
+.map__description_call svg {
+  width: 0.94vmax;
+  height: 0.94vmax;
+  color: var(--white);
+}
+
+.map__description_call_text {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  gap: 0.26vmax;
+}
+
+.map__description_call_text span {
+  font-weight: 700;
+  font-size: 0.83vmax;
+  color: var(--white);
+}
+
+@media (max-width: 1024px) {
+  .map__content {
+    width: 100%;
+    height: 50%;
+  }
+
+  .map__card_content {
+    width: 100%;
+    height: 50%;
+    padding: 2.6vmin 9.11vmin;
+  }
+
+  .map__card_content h3 {
+    font-size: 2.6vmin;
+  }
+
+  .map__description {
+    gap: 1.95vmin;
+  }
+
+  .map__description li {
+    gap: 1.95vmin;
+  }
+
+  .map__icon_frame {
+    width: 4.3vmin;
+    height: 4.3vmin;
+  }
+
+  .map__icon {
+    width: 2.66vmin;
+    height: 2.66vmin;
+  }
+
+  .map__description_text {
+    gap: 0.65vmin;
+  }
+
+  .map__description_text h4 {
+    font-size: 1.56vmin;
+  }
+
+  .map__description__content p {
+    font-size: 1.3vmin;
+  }
+
+  .map__card_content hr {
+    border-top: 0.13vmin solid var(--brown-200);
+  }
+
+  .map__description_call {
+    gap: 1.3vmin;
+    padding: 1.95vmin 0;
+    border-radius: 0.91vmin;
+    box-shadow: 0 0.52vmin 0.52vmin rgb(0, 0, 0, 0.25);
+  }
+
+  .map__description_call:hover {
+    box-shadow: 0 0.78vmin 0.42vmin rgba(0, 0, 0, 0.35);
+  }
+
+  .map__description_call svg {
+    width: 2.34vmin;
+    height: 2.34vmin;
+  }
+
+  .map__description_call_text {
+    gap: 0.65vmin;
+  }
+
+  .map__description_call_text span {
+    font-size: 2.08vmin;
+  }
+}
+
+@media (max-width: 767px) {
+  .map__content {
+    width: 100%;
+    height: 45.74%;
+  }
+
+  .map__card_content {
+    width: 100%;
+    height: 54.26%;
+    padding: 4vmin 8vmin;
+  }
+
+  .map__card_content h3 {
+    font-size: 4.27vmin;
+  }
+
+  .map__description {
+    gap: 2.67vmin;
+  }
+
+  .map__description li {
+    gap: 2.67vmin;
+  }
+
+  .map__icon_frame {
+    width: 8vmin;
+    height: 8vmin;
+  }
+
+  .map__icon {
+    width: 4vmin;
+    height: 4vmin;
+  }
+
+  .map__description_text {
+    gap: 0;
+  }
+
+  .map__description_text h4 {
+    font-size: 3.2vmin;
+  }
+
+  .map__description__content p {
+    font-size: 2.67vmin;
+  }
+
+  .map__card_content hr {
+    border-top: 0.27vmin solid var(--brown-200);
+  }
+
+  .map__description_call {
+    gap: 2.67vmin;
+    padding: 2.67vmin 0;
+    border-radius: 1.87vmin;
+    box-shadow: 0 1.07vmin 1.07vmin rgb(0, 0, 0, 0.25);
+  }
+
+  .map__description_call:hover {
+    box-shadow: 0 0.78vmin 0.42vmin rgba(0, 0, 0, 0.35);
+  }
+
+  .map__description_call svg {
+    width: 4vmin;
+    height: 4vmin;
+  }
+
+  .map__description_call_text {
+    gap: 1.33vmin;
+  }
+
+  .map__description_call_text span {
+    font-size: 3.2vmin;
+  }
+}

--- a/src/widgets/map/styles/Title.css
+++ b/src/widgets/map/styles/Title.css
@@ -1,0 +1,70 @@
+.map__title {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.78vmax;
+}
+
+.map__title_text {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.map__title_text p {
+  font-weight: 700;
+  font-size: 0.78vmax;
+  letter-spacing: 0.05em;
+  color: var(--brown-800);
+}
+
+.map__title_text h2 {
+  font-weight: 700;
+  font-size: 2.34vmax;
+  letter-spacing: 0.025em;
+  color: var(--typo-titleB);
+}
+
+.map__title hr {
+  width: 3.65vmax;
+  border: none;
+  border-top: 0.18vmax solid var(--brown-800);
+}
+
+@media (max-width: 1024px) {
+  .map__title {
+    gap: 1.95vmin;
+  }
+
+  .map__title_text p {
+    font-size: 1.95vmin;
+  }
+
+  .map__title_text h2 {
+    font-size: 5.86vmin;
+  }
+
+  .map__title hr {
+    width: 9.11vmin;
+    border-top: 0.46vmin solid var(--brown-800);
+  }
+}
+
+@media (max-width: 767px) {
+  .map__title {
+    gap: 2.67vmin;
+  }
+
+  .map__title_text p {
+    font-size: 3.2vmin;
+  }
+
+  .map__title_text h2 {
+    font-size: 8vmin;
+  }
+
+  .map__title hr {
+    width: 16vmin;
+    border-top: 0.93vmin solid var(--brown-800);
+  }
+}

--- a/src/widgets/map/styles/mapInfoCard.css
+++ b/src/widgets/map/styles/mapInfoCard.css
@@ -2,7 +2,7 @@
   background: white;
   border-radius: 0.65vmax;
   overflow: hidden;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+  box-shadow: 0 0.417vmax 1.25vmax rgba(0, 0, 0, 0.16);
   width: 15vmax;
   height: 9vmax;
 }

--- a/src/widgets/map/ui/Map.nullref.test.tsx
+++ b/src/widgets/map/ui/Map.nullref.test.tsx
@@ -41,10 +41,4 @@ describe('Map — mapRef가 null인 경우', () => {
 
     expect(mockMakeMap).not.toHaveBeenCalled();
   });
-
-  it('useRef가 null이어도 section.map은 렌더링된다', () => {
-    const { container } = render(<Map />);
-
-    expect(container.querySelector('section.map')).toBeInTheDocument();
-  });
 });

--- a/src/widgets/map/ui/Map.test.tsx
+++ b/src/widgets/map/ui/Map.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import Map from './Map';
@@ -21,70 +21,6 @@ describe('Map', () => {
       const section = container.querySelector('section');
       expect(section).toBeInTheDocument();
       expect(section).toHaveClass('map');
-    });
-
-    it('address.map__card_content 요소가 렌더링된다', () => {
-      const { container } = render(<Map />);
-
-      expect(
-        container.querySelector('address.map__card_content'),
-      ).toBeInTheDocument();
-    });
-  });
-
-  describe('제목 표시', () => {
-    it('h2 제목이 "찾아오시는 길"로 렌더링된다', () => {
-      render(<Map />);
-
-      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
-        '찾아오시는 길',
-      );
-    });
-  });
-
-  describe('교통수단 항목 렌더링', () => {
-    it('도보 항목 레이블이 표시된다', () => {
-      render(<Map />);
-
-      expect(screen.getByText('도보')).toBeInTheDocument();
-    });
-
-    it('버스 항목 레이블이 표시된다', () => {
-      render(<Map />);
-
-      expect(screen.getByText('버스')).toBeInTheDocument();
-    });
-
-    it('지하철 항목 레이블이 표시된다', () => {
-      render(<Map />);
-
-      expect(screen.getByText('지하철')).toBeInTheDocument();
-    });
-
-    it('도보 상세 라인이 표시된다', () => {
-      render(<Map />);
-
-      expect(
-        screen.getByText('부산 남구 수영로 274-16 (우) 48498'),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText('프렌즈 스크린 부산 대연점 옆 건물'),
-      ).toBeInTheDocument();
-    });
-
-    it('버스 상세 라인이 표시된다', () => {
-      render(<Map />);
-
-      expect(screen.getByText('대연역 정거장 (211m)')).toBeInTheDocument();
-      expect(screen.getByText('경성대학교 정거장 (278m)')).toBeInTheDocument();
-    });
-
-    it('지하철 상세 라인이 표시된다', () => {
-      render(<Map />);
-
-      expect(
-        screen.getByText('2호선 경성대부경대역 5번 출구 (348m)'),
-      ).toBeInTheDocument();
     });
   });
 

--- a/src/widgets/map/ui/Map.test.tsx
+++ b/src/widgets/map/ui/Map.test.tsx
@@ -23,21 +23,21 @@ describe('Map', () => {
       expect(section).toHaveClass('map');
     });
 
-    it('address.map__description 요소가 렌더링된다', () => {
+    it('address.map__card_content 요소가 렌더링된다', () => {
       const { container } = render(<Map />);
 
       expect(
-        container.querySelector('address.map__description'),
+        container.querySelector('address.map__card_content'),
       ).toBeInTheDocument();
     });
   });
 
   describe('제목 표시', () => {
-    it('h2 제목이 "INDUEL E&H Address"로 렌더링된다', () => {
+    it('h2 제목이 "찾아오시는 길"로 렌더링된다', () => {
       render(<Map />);
 
       expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
-        'INDUEL E&H Address',
+        '찾아오시는 길',
       );
     });
   });
@@ -64,7 +64,9 @@ describe('Map', () => {
     it('도보 상세 라인이 표시된다', () => {
       render(<Map />);
 
-      expect(screen.getByText('부산 남구 수영로 274-16')).toBeInTheDocument();
+      expect(
+        screen.getByText('부산 남구 수영로 274-16 (우) 48498'),
+      ).toBeInTheDocument();
       expect(
         screen.getByText('프렌즈 스크린 부산 대연점 옆 건물'),
       ).toBeInTheDocument();
@@ -73,15 +75,15 @@ describe('Map', () => {
     it('버스 상세 라인이 표시된다', () => {
       render(<Map />);
 
-      expect(screen.getByText('대연역 정거장')).toBeInTheDocument();
-      expect(screen.getByText('경성대학교 정거장')).toBeInTheDocument();
+      expect(screen.getByText('대연역 정거장 (211m)')).toBeInTheDocument();
+      expect(screen.getByText('경성대학교 정거장 (278m)')).toBeInTheDocument();
     });
 
     it('지하철 상세 라인이 표시된다', () => {
       render(<Map />);
 
       expect(
-        screen.getByText('2호선 경성대부경대역 5번 출구'),
+        screen.getByText('2호선 경성대부경대역 5번 출구 (348m)'),
       ).toBeInTheDocument();
     });
   });

--- a/src/widgets/map/ui/Map.tsx
+++ b/src/widgets/map/ui/Map.tsx
@@ -26,19 +26,17 @@ function Map() {
         <hr />
       </div>
       <div className='map__card'>
-        <div className='map__wrapper'>
-          <div ref={mapRef} className='map__content' />
-        </div>
+        <div ref={mapRef} className='map__content' />
         <address className='map__card_content'>
-          <p>(주) 인들이앤에이치 본사</p>
-          <ul>
+          <h3>(주) 인들이앤에이치 본사</h3>
+          <ul className='map__description'>
             {TRANSPORT_ITEMS.map(({ id, Icon, label, lines }) => (
               <li key={id}>
                 <div className='map__icon_frame'>
                   <Icon className='map__icon' id={id} aria-hidden='true' />
                 </div>
                 <div className='map__description_text'>
-                  <h3>{label}</h3>
+                  <h4>{label}</h4>
                   <div className='map__description__content'>
                     {lines.map((line) => (
                       <p key={line}>{line}</p>

--- a/src/widgets/map/ui/Map.tsx
+++ b/src/widgets/map/ui/Map.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react';
+import { FiPhoneCall } from 'react-icons/fi';
 
 import { TRANSPORT_ITEMS } from '@entities/map/model/transportInfo';
+import { COMPANY } from '@shared/constant';
 
 import { makeMap } from '../model/map';
 import '../styles/Map.css';
@@ -17,26 +19,45 @@ function Map() {
   return (
     <section className='map'>
       <div className='map__title'>
-        <h2>INDUEL E&H Address</h2>
+        <hgroup className='map__title_text'>
+          <p>LOCATION</p>
+          <h2>찾아오시는 길</h2>
+        </hgroup>
+        <hr />
       </div>
-      <div className='map__wrapper'>
-        <div ref={mapRef} className='map__content'></div>
+      <div className='map__card'>
+        <div className='map__wrapper'>
+          <div ref={mapRef} className='map__content' />
+        </div>
+        <address className='map__card_content'>
+          <p>(주) 인들이앤에이치 본사</p>
+          <ul>
+            {TRANSPORT_ITEMS.map(({ id, Icon, label, lines }) => (
+              <li key={id}>
+                <div className='map__icon_frame'>
+                  <Icon className='map__icon' id={id} aria-hidden='true' />
+                </div>
+                <div className='map__description_text'>
+                  <h3>{label}</h3>
+                  <div className='map__description__content'>
+                    {lines.map((line) => (
+                      <p key={line}>{line}</p>
+                    ))}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <hr />
+          <div className='map__description_call'>
+            <FiPhoneCall aria-hidden='true' />
+            <div className='map__description_call_text'>
+              <span>문의 전화:</span>
+              <span>{COMPANY.PHONE_DISPLAY}</span>
+            </div>
+          </div>
+        </address>
       </div>
-      <address className='map__description'>
-        <ul>
-          {TRANSPORT_ITEMS.map(({ id, Icon, label, lines }) => (
-            <li key={id}>
-              <div className='map__description_title'>
-                <Icon className='map__icon' id={id} aria-hidden='true' />
-                <h3>{label}</h3>
-              </div>
-              {lines.map((line) => (
-                <p key={line}>{line}</p>
-              ))}
-            </li>
-          ))}
-        </ul>
-      </address>
     </section>
   );
 }

--- a/src/widgets/map/ui/Map.tsx
+++ b/src/widgets/map/ui/Map.tsx
@@ -47,13 +47,13 @@ function Map() {
             ))}
           </ul>
           <hr />
-          <div className='map__description_call'>
+          <a href={`tel:${COMPANY.PHONE}`} className='map__description_call'>
             <FiPhoneCall aria-hidden='true' />
             <div className='map__description_call_text'>
               <span>문의 전화:</span>
               <span>{COMPANY.PHONE_DISPLAY}</span>
             </div>
-          </div>
+          </a>
         </address>
       </div>
     </section>

--- a/src/widgets/map/ui/Map.tsx
+++ b/src/widgets/map/ui/Map.tsx
@@ -17,9 +17,7 @@ function Map() {
   return (
     <section className='map'>
       <div className='map__title'>
-        <hr aria-hidden='true' />
         <h2>INDUEL E&H Address</h2>
-        <hr aria-hidden='true' />
       </div>
       <div className='map__wrapper'>
         <div ref={mapRef} className='map__content'></div>

--- a/src/widgets/map/ui/Map.tsx
+++ b/src/widgets/map/ui/Map.tsx
@@ -1,13 +1,11 @@
 import { useEffect, useRef } from 'react';
-import { FiPhoneCall } from 'react-icons/fi';
-
-import { TRANSPORT_ITEMS } from '@entities/map/model/transportInfo';
-import { COMPANY } from '@shared/constant';
 
 import { makeMap } from '../model/map';
 import '../styles/Map.css';
 import '../styles/mapInfoCard.css';
 import '../styles/mapMarker.css';
+import { MapCard } from './MapCard';
+import { MapTitle } from './Title';
 
 function Map() {
   const mapRef = useRef<HTMLDivElement>(null);
@@ -18,43 +16,10 @@ function Map() {
 
   return (
     <section className='map'>
-      <div className='map__title'>
-        <hgroup className='map__title_text'>
-          <p>LOCATION</p>
-          <h2>찾아오시는 길</h2>
-        </hgroup>
-        <hr />
-      </div>
+      <MapTitle />
       <div className='map__card'>
         <div ref={mapRef} className='map__content' />
-        <address className='map__card_content'>
-          <h3>(주) 인들이앤에이치 본사</h3>
-          <ul className='map__description'>
-            {TRANSPORT_ITEMS.map(({ id, Icon, label, lines }) => (
-              <li key={id}>
-                <div className='map__icon_frame'>
-                  <Icon className='map__icon' id={id} aria-hidden='true' />
-                </div>
-                <div className='map__description_text'>
-                  <h4>{label}</h4>
-                  <div className='map__description__content'>
-                    {lines.map((line) => (
-                      <p key={line}>{line}</p>
-                    ))}
-                  </div>
-                </div>
-              </li>
-            ))}
-          </ul>
-          <hr />
-          <a href={`tel:${COMPANY.PHONE}`} className='map__description_call'>
-            <FiPhoneCall aria-hidden='true' />
-            <div className='map__description_call_text'>
-              <span>문의 전화:</span>
-              <span>{COMPANY.PHONE_DISPLAY}</span>
-            </div>
-          </a>
-        </address>
+        <MapCard />
       </div>
     </section>
   );

--- a/src/widgets/map/ui/MapCard.test.tsx
+++ b/src/widgets/map/ui/MapCard.test.tsx
@@ -1,0 +1,101 @@
+import { TRANSPORT_ITEMS } from '@entities/map/model/transportInfo';
+import { COMPANY } from '@shared/constant';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MapCard } from './MapCard';
+
+describe('MapCard', () => {
+  describe('회사 정보 표시', () => {
+    it('회사명이 h3로 표시된다', () => {
+      render(<MapCard />);
+
+      expect(
+        screen.getByRole('heading', {
+          level: 3,
+          name: '(주) 인들이앤에이치 본사',
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it('전화 링크가 올바르게 렌더링된다', () => {
+      render(<MapCard />);
+
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('href', `tel:${COMPANY.PHONE}`);
+    });
+
+    it('전화 번호가 표시된다', () => {
+      render(<MapCard />);
+
+      expect(screen.getByText(COMPANY.PHONE_DISPLAY)).toBeInTheDocument();
+    });
+
+    it('"문의 전화:" 텍스트가 존재한다', () => {
+      render(<MapCard />);
+
+      expect(screen.getByText('문의 전화:')).toBeInTheDocument();
+    });
+  });
+
+  describe('교통 정보 리스트', () => {
+    it('TRANSPORT_ITEMS 개수만큼 리스트가 렌더링된다', () => {
+      render(<MapCard />);
+
+      const items = screen.getAllByRole('listitem');
+      expect(items.length).toBe(TRANSPORT_ITEMS.length);
+    });
+
+    it('각 transport label이 표시된다', () => {
+      render(<MapCard />);
+
+      TRANSPORT_ITEMS.forEach(({ label }) => {
+        expect(screen.getByText(label)).toBeInTheDocument();
+      });
+    });
+
+    it('각 transport lines가 모두 표시된다', () => {
+      render(<MapCard />);
+
+      TRANSPORT_ITEMS.forEach(({ lines }) => {
+        lines.forEach((line) => {
+          expect(screen.getByText(line)).toBeInTheDocument();
+        });
+      });
+    });
+
+    it('각 transport label이 h4 요소로 표시된다', () => {
+      render(<MapCard />);
+
+      const headings = screen.getAllByRole('heading', { level: 4 });
+      expect(headings).toHaveLength(TRANSPORT_ITEMS.length);
+      TRANSPORT_ITEMS.forEach(({ label }, i) => {
+        expect(headings[i]).toHaveTextContent(label);
+      });
+    });
+  });
+
+  describe('시맨틱 구조', () => {
+    it('address 요소가 존재한다', () => {
+      const { container } = render(<MapCard />);
+
+      const address = container.querySelector('address');
+      expect(address).toBeInTheDocument();
+      expect(address).toHaveClass('map__card_content');
+    });
+
+    it('ul.map__description 리스트가 존재한다', () => {
+      const { container } = render(<MapCard />);
+
+      expect(
+        container.querySelector('ul.map__description'),
+      ).toBeInTheDocument();
+    });
+
+    it('hr 요소가 존재한다', () => {
+      const { container } = render(<MapCard />);
+
+      expect(container.querySelector('hr')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/widgets/map/ui/MapCard.tsx
+++ b/src/widgets/map/ui/MapCard.tsx
@@ -1,0 +1,42 @@
+import { FiPhoneCall } from 'react-icons/fi';
+
+import { TRANSPORT_ITEMS } from '@entities/map/model/transportInfo';
+import { COMPANY } from '@shared/constant';
+
+import '../styles/MapCard.css';
+
+export function MapCard() {
+  return (
+    <address className='map__card_content'>
+      <h3>(주) 인들이앤에이치 본사</h3>
+
+      <ul className='map__description'>
+        {TRANSPORT_ITEMS.map(({ id, Icon, label, lines }) => (
+          <li key={id}>
+            <div className='map__icon_frame'>
+              <Icon className='map__icon' id={id} aria-hidden='true' />
+            </div>
+            <div className='map__description_text'>
+              <h4>{label}</h4>
+              <div className='map__description__content'>
+                {lines.map((line) => (
+                  <p key={line}>{line}</p>
+                ))}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <hr />
+
+      <a href={`tel:${COMPANY.PHONE}`} className='map__description_call'>
+        <FiPhoneCall aria-hidden='true' />
+        <div className='map__description_call_text'>
+          <span>문의 전화:</span>
+          <span>{COMPANY.PHONE_DISPLAY}</span>
+        </div>
+      </a>
+    </address>
+  );
+}

--- a/src/widgets/map/ui/Title.test.tsx
+++ b/src/widgets/map/ui/Title.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MapTitle } from './Title';
+
+describe('MapTitle', () => {
+  describe('텍스트 렌더링', () => {
+    it('"LOCATION" 텍스트가 p 요소로 표시된다', () => {
+      const { container } = render(<MapTitle />);
+      const p = container.querySelector('p');
+      expect(p).toHaveTextContent('LOCATION');
+    });
+
+    it('"찾아오시는 길" 텍스트가 표시된다', () => {
+      render(<MapTitle />);
+      expect(screen.getByText('찾아오시는 길')).toBeInTheDocument();
+    });
+  });
+
+  describe('시맨틱 구조', () => {
+    it('h2 요소가 존재한다', () => {
+      render(<MapTitle />);
+      const heading = screen.getByRole('heading', { level: 2 });
+      expect(heading).toHaveTextContent('찾아오시는 길');
+    });
+
+    it('hgroup이 존재한다', () => {
+      const { container } = render(<MapTitle />);
+      const hgroup = container.querySelector('hgroup');
+
+      expect(hgroup).toBeInTheDocument();
+      expect(hgroup).toHaveClass('map__title_text');
+    });
+
+    it('hr 요소가 렌더링된다', () => {
+      const { container } = render(<MapTitle />);
+      const hr = container.querySelector('hr');
+
+      expect(hr).toBeInTheDocument();
+    });
+  });
+
+  describe('루트 요소', () => {
+    it('최상위 div에 map__title 클래스가 적용된다', () => {
+      const { container } = render(<MapTitle />);
+      const root = container.firstChild;
+
+      expect(root).toHaveClass('map__title');
+    });
+  });
+});

--- a/src/widgets/map/ui/Title.tsx
+++ b/src/widgets/map/ui/Title.tsx
@@ -1,0 +1,13 @@
+import '../styles/Title.css';
+
+export function MapTitle() {
+  return (
+    <div className='map__title'>
+      <hgroup className='map__title_text'>
+        <p>LOCATION</p>
+        <h2>찾아오시는 길</h2>
+      </hgroup>
+      <hr />
+    </div>
+  );
+}


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #17

### Map 페이지 전면 개선

- Desktop 디자인을 전면 수정하고, Tablet / Mobile 반응형 레이아웃을 새로 구현했습니다.
- 기존 고정 `px` 단위를 `vmax` / `vmin` 단위로 통일해 뷰포트에 자연스럽게 대응하도록 했습니다.
- 지도 배율, 마커, 인포카드 구조를 정리하고 우편번호 및 거리 정보를 추가했습니다.

### 핵심 변화

#### 변경 전
- Desktop 전용 레이아웃, px 고정 단위
- 교통 정보 카드 구조 미흡

#### 변경 후
- Desktop / Tablet (`≤1024px`) / Mobile (`≤768px`) 3단계 반응형
- `vmax` / `vmin` 단위 기반 스케일링
- 교통 정보(버스·지하철·자가용·주차) 카드 완성, 우편번호·거리 표시 추가

# 📋 작업 내용

- `✨ feat: desktop 버전 디자인 전면 수정` — 카드 레이아웃·타이포·컬러 전면 개편
- `✨ feat: tablet 버전 구현` — `@media (max-width: 1024px)` 반응형 추가
- `✨ feat: mobile 버전 구현` — `@media (max-width: 768px)` 반응형 추가
- `🧹 clean: px → vmax 단위 수정` — 모든 고정 px를 뷰포트 상대 단위로 변환
- `✨ feat: 우편 번호 및 거리 추가` — 교통 정보 데이터 보강
- `👹 fix: desktop 반응형 수정` — 브레이크포인트 경계 버그 수정
- `🔨 refactor: map html 구조 재변경` — 시맨틱 마크업 개선
- 테스트 코드 업데이트 (`map.test.ts`, `mapInfoCard.test.ts`, `Map.test.tsx`)

# 📷 스크린 샷 (선택 사항)

- 개선후
    - PC
      <img width="2557" height="1078" alt="image" src="https://github.com/user-attachments/assets/3ed63326-faac-4e87-84dc-16b89fc6db64" />
    - Tablet
      <img width="767" height="899" alt="image" src="https://github.com/user-attachments/assets/8a6a0a49-ae3f-4c25-9659-5d8e50a4e6f5" />
    - Mobile
       <img width="374" height="680" alt="image" src="https://github.com/user-attachments/assets/4d0227d9-8a95-401f-b434-b2e34d4a1a43" />

- 변경전
    - PC
      <img width="1535" height="750" alt="image" src="https://github.com/user-attachments/assets/e4c0dfc1-0d73-4f97-81ad-ac24a2948cc5" />
    - Tablet
      <img width="767" height="900" alt="image" src="https://github.com/user-attachments/assets/0c89ea2e-3869-40b3-8806-7905425a47f5" />
    - Mobile
      <img width="371" height="679" alt="image" src="https://github.com/user-attachments/assets/7b3db28b-967a-4cc3-a7a4-855263682b34" />
