### PR TITLE
👹 fix: 환경변수 기반 header 테마 초기값 설정

### DIFF
--- a/src/widgets/header/model/useIsHero.ts
+++ b/src/widgets/header/model/useIsHero.ts
@@ -1,7 +1,11 @@
 import { useEffect, useState } from 'react';
 
+const DEV_WIDGET: string | undefined = import.meta.env.VITE_DEV_WIDGET;
+
 export function useIsHero(): boolean {
-  const [isHero, setIsHero] = useState(() => !!document.querySelector('.hero'));
+  const [isHero, setIsHero] = useState(
+    DEV_WIDGET === undefined || DEV_WIDGET === 'hero',
+  );
 
   useEffect(() => {
     const hero = document.querySelector('.hero');

--- a/src/widgets/header/model/useIsHero.ts
+++ b/src/widgets/header/model/useIsHero.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 export function useIsHero(): boolean {
-  const [isHero, setIsHero] = useState(true);
+  const [isHero, setIsHero] = useState(() => !!document.querySelector('.hero'));
 
   useEffect(() => {
     const hero = document.querySelector('.hero');


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue
- #71 

### 초기 렌더링 시 헤더 색상 flickering 수정

- `useIsHero` 초기값이 `true`로 고정되어 있어, Hero 섹션이 없는 도메인(`dev:map` 등)에서 헤더가 잠깐 투명색으로 보이는 flickering 발생
- DOM 조회 방식은 형제 컴포넌트가 아직 mount되지 않은 시점에 실행되어 항상 `false`를 반환하는 문제 존재
- `VITE_DEV_WIDGET` 환경변수를 통해 현재 개발 도메인을 판별, 초기값을 정확하게 설정하도록 수정

### 핵심 변화

#### 변경 전

```ts
const [isHero, setIsHero] = useState(true);
```

#### 변경 후

```ts
const DEV_WIDGET: string | undefined = import.meta.env.VITE_DEV_WIDGET;

const [isHero, setIsHero] = useState(
  DEV_WIDGET === undefined || DEV_WIDGET === 'hero',
);
```

# 📋 작업 내용

- `VITE_DEV_WIDGET` 미설정(전체 앱 / 프로덕션) → `true`
- `VITE_DEV_WIDGET=hero` → `true`
- `VITE_DEV_WIDGET=map` 등 → `false`
- DOM 조회 없이 빌드 타임 환경변수만 사용하므로 React Compiler 경고 없음, flickering 없음