### PR TITLE
⚡️ perf: Hero Three.js 성능 개선 및 FSD 구조 분리

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:hero": "cross-env VITE_DEV_WIDGET=hero vite",
+    "dev:hero": "cross-env VITE_DEV_WIDGET=hero VITE_SHOW_DOWN_ICON=true vite",
     "dev:vision": "cross-env VITE_DEV_WIDGET=vision vite",
     "dev:history": "cross-env VITE_DEV_WIDGET=history vite",
     "dev:award": "cross-env VITE_DEV_WIDGET=award vite",

--- a/src/shared/lib/three/animation/waveAnimation.ts
+++ b/src/shared/lib/three/animation/waveAnimation.ts
@@ -1,4 +1,4 @@
-import { Camera, Clock, Scene, WebGLRenderer } from 'three';
+import { Camera, Scene, WebGLRenderer } from 'three';
 
 import type { TubeData } from '../objects/type';
 
@@ -16,8 +16,8 @@ export function startWaveAnimation(
   const targetFPS = isMobile ? 30 : 60;
   const frameInterval = 1000 / targetFPS;
 
-  const clock = new Clock();
   let rafId: number;
+  let startTime: number | null = null;
   let lastFrameTime = 0;
 
   function animate(currentTime: number) {
@@ -28,7 +28,8 @@ export function startWaveAnimation(
 
     lastFrameTime = currentTime - (deltaTime % frameInterval);
 
-    const time = clock.getElapsedTime();
+    if (startTime === null) startTime = currentTime;
+    const time = (currentTime - startTime) / 1000;
 
     for (const { posAttr, baseY, geo } of tubes) {
       const count = posAttr.count;

--- a/src/shared/lib/three/animation/waveAnimation.ts
+++ b/src/shared/lib/three/animation/waveAnimation.ts
@@ -1,4 +1,4 @@
-import { Camera, Scene, WebGLRenderer } from 'three';
+import type { Camera, Scene, WebGLRenderer } from 'three';
 
 import type { TubeData } from '../objects/type';
 
@@ -31,18 +31,16 @@ export function startWaveAnimation(
     if (startTime === null) startTime = currentTime;
     const time = (currentTime - startTime) / 1000;
 
-    for (const { posAttr, baseY, geo } of tubes) {
+    for (const { posAttr, baseY, baseZ } of tubes) {
       const count = posAttr.count;
       for (let i = 0; i < count; i++) {
-        const z = posAttr.getZ(i);
         posAttr.setY(
           i,
-          baseY[i] + Math.sin(z * WAVE_FREQ + time * WAVE_SPEED) * WAVE_AMP,
+          baseY[i] +
+            Math.sin(baseZ[i] * WAVE_FREQ + time * WAVE_SPEED) * WAVE_AMP,
         );
       }
       posAttr.needsUpdate = true;
-
-      geo.computeVertexNormals();
     }
 
     renderer.render(scene, camera);

--- a/src/shared/lib/three/objects/createWaveTubes.ts
+++ b/src/shared/lib/three/objects/createWaveTubes.ts
@@ -1,19 +1,15 @@
 import {
-  BufferAttribute,
+  type BufferAttribute,
   Color,
   CylinderGeometry,
   Group,
   Mesh,
   MeshStandardMaterial,
-  Scene,
 } from 'three';
 
 import type { TubeData } from './type';
 
-export function createWaveTubes(scene: Scene): {
-  group: Group;
-  tubes: TubeData[];
-} {
+export function createWaveTubes(): { group: Group; tubes: TubeData[] } {
   const isMobile = window.innerWidth < 768;
 
   const TUBE_COUNT = isMobile ? 20 : 30;
@@ -25,7 +21,6 @@ export function createWaveTubes(scene: Scene): {
 
   const group = new Group();
   group.rotation.y = -Math.PI / 4;
-  scene.add(group);
 
   const color = new Color(0x000000);
   const sharedMaterial = new MeshStandardMaterial({
@@ -48,15 +43,17 @@ export function createWaveTubes(scene: Scene): {
 
     const posAttr = geometry.attributes.position as BufferAttribute;
     const baseY = new Float32Array(posAttr.count);
+    const baseZ = new Float32Array(posAttr.count);
     for (let j = 0; j < posAttr.count; j++) {
       baseY[j] = posAttr.getY(j);
+      baseZ[j] = posAttr.getZ(j);
     }
 
     const mesh = new Mesh(geometry, sharedMaterial);
     mesh.position.set((i - (TUBE_COUNT - 1) / 2) * TUBE_SPACING, 0, -i * 0.18);
     mesh.frustumCulled = false;
     group.add(mesh);
-    tubes.push({ posAttr, baseY, geo: geometry });
+    tubes.push({ posAttr, baseY, baseZ });
   }
 
   return { group, tubes };

--- a/src/shared/lib/three/objects/type.ts
+++ b/src/shared/lib/three/objects/type.ts
@@ -1,7 +1,7 @@
-import type { BufferAttribute, BufferGeometry } from 'three';
+import type { BufferAttribute } from 'three';
 
 export type TubeData = {
   posAttr: BufferAttribute;
   baseY: Float32Array;
-  geo: BufferGeometry;
+  baseZ: Float32Array;
 };

--- a/src/shared/lib/three/utils/attachResizeHandler.ts
+++ b/src/shared/lib/three/utils/attachResizeHandler.ts
@@ -1,16 +1,26 @@
 import type { PerspectiveCamera, WebGLRenderer } from 'three';
 
+const DEBOUNCE_MS = 100;
+
 export function attachResizeHandler(
   camera: PerspectiveCamera,
   renderer: WebGLRenderer,
 ) {
+  let timeoutId: ReturnType<typeof setTimeout>;
+
   function onResize() {
-    camera.aspect = window.innerWidth / window.innerHeight;
-    camera.updateProjectionMatrix();
-    renderer.setSize(window.innerWidth, window.innerHeight);
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    }, DEBOUNCE_MS);
   }
 
   window.addEventListener('resize', onResize);
 
-  return () => window.removeEventListener('resize', onResize);
+  return () => {
+    clearTimeout(timeoutId);
+    window.removeEventListener('resize', onResize);
+  };
 }

--- a/src/widgets/hero/model/heroConfig.ts
+++ b/src/widgets/hero/model/heroConfig.ts
@@ -1,0 +1,3 @@
+export const showScrollArrow =
+  import.meta.env.MODE === 'production' ||
+  import.meta.env.VITE_SHOW_DOWN_ICON === 'true';

--- a/src/widgets/hero/model/useWaveBackground.test.tsx
+++ b/src/widgets/hero/model/useWaveBackground.test.tsx
@@ -1,0 +1,186 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useWaveBackground } from './useWaveBackground';
+
+// Three.js 유틸리티 mock — jsdom은 WebGL을 지원하지 않음
+const mockCancelAnimation = vi.hoisted(() => vi.fn());
+const mockRemoveResizeListener = vi.hoisted(() => vi.fn());
+const mockDispose = vi.hoisted(() => vi.fn());
+const mockSceneAdd = vi.hoisted(() => vi.fn());
+const mockScene = vi.hoisted(() => ({ add: mockSceneAdd }));
+const mockCamera = vi.hoisted(() => ({}));
+const mockRenderer = vi.hoisted(() => ({ dispose: mockDispose }));
+const mockGroup = vi.hoisted(() => ({}));
+const mockTubes = vi.hoisted(() => [] as unknown[]);
+
+const mockStartWaveAnimation = vi.hoisted(() =>
+  vi.fn(() => mockCancelAnimation),
+);
+const mockCreateCamera = vi.hoisted(() => vi.fn(() => mockCamera));
+const mockCreateLights = vi.hoisted(() => vi.fn());
+const mockCreateRenderer = vi.hoisted(() => vi.fn(() => mockRenderer));
+const mockCreateScene = vi.hoisted(() => vi.fn(() => mockScene));
+const mockCreateWaveTubes = vi.hoisted(() =>
+  vi.fn(() => ({ group: mockGroup, tubes: mockTubes })),
+);
+const mockAttachResizeHandler = vi.hoisted(() =>
+  vi.fn(() => mockRemoveResizeListener),
+);
+
+vi.mock('@shared/lib/three/animation/waveAnimation', () => ({
+  startWaveAnimation: mockStartWaveAnimation,
+}));
+vi.mock('@shared/lib/three/core/createCamera', () => ({
+  createCamera: mockCreateCamera,
+}));
+vi.mock('@shared/lib/three/core/createLights', () => ({
+  createLights: mockCreateLights,
+}));
+vi.mock('@shared/lib/three/core/createRenderer', () => ({
+  createRenderer: mockCreateRenderer,
+}));
+vi.mock('@shared/lib/three/core/createScene', () => ({
+  createScene: mockCreateScene,
+}));
+vi.mock('@shared/lib/three/objects/createWaveTubes', () => ({
+  createWaveTubes: mockCreateWaveTubes,
+}));
+vi.mock('@shared/lib/three/utils/attachResizeHandler', () => ({
+  attachResizeHandler: mockAttachResizeHandler,
+}));
+
+function WaveCanvas() {
+  const ref = useWaveBackground();
+  return <canvas ref={ref} />;
+}
+
+describe('useWaveBackground', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Three.js 초기화 파이프라인', () => {
+    it('마운트 시 Three.js 초기화 함수들이 호출된다', () => {
+      render(<WaveCanvas />);
+
+      expect(mockCreateScene).toHaveBeenCalledOnce();
+      expect(mockCreateCamera).toHaveBeenCalledOnce();
+      expect(mockCreateRenderer).toHaveBeenCalledOnce();
+      expect(mockCreateLights).toHaveBeenCalledOnce();
+      expect(mockCreateWaveTubes).toHaveBeenCalledOnce();
+    });
+
+    it('createRenderer에 canvas 엘리먼트가 전달된다', () => {
+      const { container } = render(<WaveCanvas />);
+
+      const canvas = container.querySelector('canvas');
+      expect(mockCreateRenderer).toHaveBeenCalledWith(canvas);
+    });
+
+    it('createLights에 scene이 전달된다', () => {
+      render(<WaveCanvas />);
+
+      expect(mockCreateLights).toHaveBeenCalledWith(mockScene);
+    });
+
+    it('createWaveTubes가 인자 없이 호출된다', () => {
+      render(<WaveCanvas />);
+
+      expect(mockCreateWaveTubes).toHaveBeenCalledWith();
+    });
+
+    it('createWaveTubes의 group이 scene에 추가된다', () => {
+      render(<WaveCanvas />);
+
+      expect(mockSceneAdd).toHaveBeenCalledWith(mockGroup);
+    });
+
+    it('startWaveAnimation에 올바른 인자가 전달된다', () => {
+      render(<WaveCanvas />);
+
+      expect(mockStartWaveAnimation).toHaveBeenCalledWith(
+        mockRenderer,
+        mockScene,
+        mockCamera,
+        mockTubes,
+      );
+    });
+
+    it('attachResizeHandler에 camera와 renderer가 전달된다', () => {
+      render(<WaveCanvas />);
+
+      expect(mockAttachResizeHandler).toHaveBeenCalledWith(
+        mockCamera,
+        mockRenderer,
+      );
+    });
+  });
+
+  describe('클린업 (언마운트)', () => {
+    it('언마운트 시 애니메이션이 정지된다', () => {
+      const { unmount } = render(<WaveCanvas />);
+
+      unmount();
+
+      expect(mockCancelAnimation).toHaveBeenCalledOnce();
+    });
+
+    it('언마운트 시 리사이즈 핸들러가 해제된다', () => {
+      const { unmount } = render(<WaveCanvas />);
+
+      unmount();
+
+      expect(mockRemoveResizeListener).toHaveBeenCalledOnce();
+    });
+
+    it('언마운트 시 renderer가 해제된다', () => {
+      const { unmount } = render(<WaveCanvas />);
+
+      unmount();
+
+      expect(mockDispose).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('Three.js 초기화 실패 시', () => {
+    it('createScene에서 에러 발생 시 cleanup 함수가 호출되지 않는다', () => {
+      mockCreateScene.mockImplementationOnce(() => {
+        throw new Error('WebGL not supported');
+      });
+
+      const { unmount } = render(<WaveCanvas />);
+      unmount();
+
+      expect(mockCancelAnimation).not.toHaveBeenCalled();
+      expect(mockRemoveResizeListener).not.toHaveBeenCalled();
+      expect(mockDispose).not.toHaveBeenCalled();
+    });
+
+    it('createRenderer에서 에러 발생 시 cleanup 함수가 호출되지 않는다', () => {
+      mockCreateRenderer.mockImplementationOnce(() => {
+        throw new Error('Canvas context creation failed');
+      });
+
+      const { unmount } = render(<WaveCanvas />);
+      unmount();
+
+      expect(mockCancelAnimation).not.toHaveBeenCalled();
+      expect(mockRemoveResizeListener).not.toHaveBeenCalled();
+      expect(mockDispose).not.toHaveBeenCalled();
+    });
+
+    it('createWaveTubes에서 에러 발생 시 cleanup 함수가 등록되지 않는다', () => {
+      mockCreateWaveTubes.mockImplementationOnce(() => {
+        throw new Error('Geometry creation failed');
+      });
+
+      const { unmount } = render(<WaveCanvas />);
+      unmount();
+
+      expect(mockCancelAnimation).not.toHaveBeenCalled();
+      expect(mockRemoveResizeListener).not.toHaveBeenCalled();
+      expect(mockDispose).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/widgets/hero/model/useWaveBackground.ts
+++ b/src/widgets/hero/model/useWaveBackground.ts
@@ -26,7 +26,7 @@ export function useWaveBackground() {
 
       createLights(scene);
 
-      const { group, tubes } = createWaveTubes(scene);
+      const { group, tubes } = createWaveTubes();
       scene.add(group);
 
       cancelAnimation = startWaveAnimation(renderer, scene, camera, tubes);

--- a/src/widgets/hero/model/useWaveBackground.ts
+++ b/src/widgets/hero/model/useWaveBackground.ts
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from 'react';
+
+import { startWaveAnimation } from '@shared/lib/three/animation/waveAnimation';
+import { createCamera } from '@shared/lib/three/core/createCamera';
+import { createLights } from '@shared/lib/three/core/createLights';
+import { createRenderer } from '@shared/lib/three/core/createRenderer';
+import { createScene } from '@shared/lib/three/core/createScene';
+import { createWaveTubes } from '@shared/lib/three/objects/createWaveTubes';
+import { attachResizeHandler } from '@shared/lib/three/utils/attachResizeHandler';
+
+export function useWaveBackground() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    let cancelAnimation: (() => void) | undefined;
+    let removeResizeListener: (() => void) | undefined;
+    let renderer: ReturnType<typeof createRenderer> | undefined;
+
+    try {
+      const scene = createScene();
+      const camera = createCamera();
+      renderer = createRenderer(canvas);
+
+      createLights(scene);
+
+      const { group, tubes } = createWaveTubes(scene);
+      scene.add(group);
+
+      cancelAnimation = startWaveAnimation(renderer, scene, camera, tubes);
+      removeResizeListener = attachResizeHandler(camera, renderer);
+    } catch {
+      return;
+    }
+
+    return () => {
+      cancelAnimation?.();
+      removeResizeListener?.();
+      renderer?.dispose();
+    };
+  }, []);
+
+  return canvasRef;
+}

--- a/src/widgets/hero/styles/Hero.css
+++ b/src/widgets/hero/styles/Hero.css
@@ -22,15 +22,15 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 3.64vw;
+  gap: 3.64vmax;
   animation: fade-in 1.2s ease-out forwards;
 }
 
 .hero__logo {
   height: 16.67vmax;
-  filter: drop-shadow(0 0 40px rgba(0, 0, 0, 1))
-    drop-shadow(0 0 20px rgba(0, 0, 0, 1))
-    drop-shadow(0 0 60px rgba(0, 0, 0, 1));
+  filter: drop-shadow(0 0 2.08vmax rgba(0, 0, 0, 1))
+    drop-shadow(0 0 1.04vmax rgba(0, 0, 0, 1))
+    drop-shadow(0 0 3.125vmax rgba(0, 0, 0, 1));
 }
 
 .hero__company-text {
@@ -40,9 +40,9 @@
   white-space: nowrap;
   gap: 0.52vmax;
   text-shadow:
-    0 0 40px rgba(0, 0, 0, 1),
-    0 0 20px rgba(0, 0, 0, 1),
-    0 0 60px rgba(0, 0, 0, 1);
+    0 0 2.08vmax rgba(0, 0, 0, 1),
+    0 0 1.04vmax rgba(0, 0, 0, 1),
+    0 0 3.125vmax rgba(0, 0, 0, 1);
 }
 
 .hero__company-text hgroup {
@@ -103,6 +103,9 @@
   --size: 3.13vmax;
   width: var(--size);
   height: var(--size);
+  filter: drop-shadow(0 0 2.08vmax rgba(0, 0, 0, 1))
+    drop-shadow(0 0 1.04vmax rgba(0, 0, 0, 1))
+    drop-shadow(0 0 3.125vmax rgba(0, 0, 0, 1));
 }
 
 @media (max-width: 1024px) {
@@ -136,7 +139,9 @@
     order: 2;
     height: 37.5vmin;
     width: auto;
-    filter: none;
+    filter: drop-shadow(0 0 5.21vmin rgba(0, 0, 0, 1))
+      drop-shadow(0 0 2.6vmin rgba(0, 0, 0, 1))
+      drop-shadow(0 0 7.81vmin rgba(0, 0, 0, 1));
   }
 
   .hero__company-text {
@@ -145,6 +150,10 @@
     order: 1;
     align-items: center;
     gap: 1.82vmin;
+    text-shadow:
+      0 0 5.21vmin rgba(0, 0, 0, 1),
+      0 0 2.6vmin rgba(0, 0, 0, 1),
+      0 0 7.81vmin rgba(0, 0, 0, 1);
   }
 
   .hero__company-text hgroup {
@@ -173,6 +182,9 @@
     --size: 6.51vmin;
     width: var(--size);
     height: var(--size);
+    filter: drop-shadow(0 0 5.21vmin rgba(0, 0, 0, 1))
+      drop-shadow(0 0 2.6vmin rgba(0, 0, 0, 1))
+      drop-shadow(0 0 7.81vmin rgba(0, 0, 0, 1));
   }
 }
 
@@ -186,10 +198,17 @@
 
   .hero__logo {
     height: 54.13vmin;
+    filter: drop-shadow(0 0 10.67vmin rgba(0, 0, 0, 1))
+      drop-shadow(0 0 5.33vmin rgba(0, 0, 0, 1))
+      drop-shadow(0 0 16vmin rgba(0, 0, 0, 1));
   }
 
   .hero__company-text {
     gap: 2.13vmin;
+    text-shadow:
+      0 0 10.67vmin rgba(0, 0, 0, 1),
+      0 0 5.33vmin rgba(0, 0, 0, 1),
+      0 0 16vmin rgba(0, 0, 0, 1);
   }
 
   .hero__company-text hgroup {
@@ -214,5 +233,8 @@
     --size: 10.93vmin;
     width: var(--size);
     height: var(--size);
+    filter: drop-shadow(0 0 10.67vmin rgba(0, 0, 0, 1))
+      drop-shadow(0 0 5.33vmin rgba(0, 0, 0, 1))
+      drop-shadow(0 0 16vmin rgba(0, 0, 0, 1));
   }
 }

--- a/src/widgets/hero/styles/Hero.css
+++ b/src/widgets/hero/styles/Hero.css
@@ -28,7 +28,6 @@
 
 .hero__logo {
   height: 16.67vmax;
-  aspect-ratio: 649 / 748;
   filter: drop-shadow(0 0 40px rgba(0, 0, 0, 1))
     drop-shadow(0 0 20px rgba(0, 0, 0, 1))
     drop-shadow(0 0 60px rgba(0, 0, 0, 1));
@@ -110,20 +109,28 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: space-between;
     filter: none;
     animation: fade-in-mobile 1.2s ease-out forwards;
     gap: 0;
+    padding-top: 9.77vmin;
+  }
+
+  .hero__company::after {
+    content: '';
+    display: block;
+    order: 3;
+    height: calc(9.11vmin+ 4.56vmin);
   }
 
   .hero__logo {
     position: static;
     transform: none;
     order: 2;
-    width: 47%;
-    max-height: 32vh;
-    height: auto;
-    filter: drop-shadow(0 0 40px rgba(0, 0, 0, 1));
-    margin: auto;
+    height: 37.5vmin;
+    width: auto;
+    filter: none;
+    margin: 0;
   }
 
   .hero__company-text {
@@ -132,11 +139,10 @@
     order: 1;
     align-items: center;
     gap: 1.82vmin;
-    padding-top: 6.222vh;
   }
 
   .hero__company-name {
-    font-size: 10.42vmin;
+    font-size: 9.11vmin;
   }
 
   .hero__company-name-en {
@@ -144,7 +150,10 @@
   }
 
   .hero__established {
-    bottom: 7.23%;
+    position: absolute;
+    bottom: 9.11vmin;
+    left: 50%;
+    transform: translateX(-50%);
     font-size: 4.56vmin;
   }
 
@@ -157,7 +166,38 @@
 }
 
 @media (max-width: 767px) {
+  .hero__company {
+    padding-top: 16vmin;
+  }
+  .hero__company::after {
+    height: calc(13.33vmin + 4.53vmin);
+  }
+
+  .hero__logo {
+    height: 54.13vmin;
+  }
+
   .hero__company-text {
-    padding-top: 8.24vh;
+    gap: 2.13vmin;
+  }
+
+  .hero__company-name {
+    font-size: 10.67vmin;
+  }
+
+  .hero__company-name-en {
+    font-size: 5.33vmin;
+  }
+
+  .hero__established {
+    font-size: 4.53vmin;
+    bottom: 13.33vmin;
+  }
+
+  .hero__down-icon {
+    bottom: 2%;
+    --size: 10.93vmin;
+    width: var(--size);
+    height: var(--size);
   }
 }

--- a/src/widgets/hero/styles/Hero.css
+++ b/src/widgets/hero/styles/Hero.css
@@ -130,7 +130,6 @@
     height: 37.5vmin;
     width: auto;
     filter: none;
-    margin: 0;
   }
 
   .hero__company-text {

--- a/src/widgets/hero/styles/Hero.css
+++ b/src/widgets/hero/styles/Hero.css
@@ -45,6 +45,13 @@
     0 0 60px rgba(0, 0, 0, 1);
 }
 
+.hero__company-text hgroup {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.52vmax;
+}
+
 .hero__company-name {
   font-size: 6.25vmax;
 }
@@ -140,6 +147,11 @@
     gap: 1.82vmin;
   }
 
+  .hero__company-text hgroup {
+    align-items: center;
+    gap: 1.82vmin;
+  }
+
   .hero__company-name {
     font-size: 9.11vmin;
   }
@@ -177,6 +189,10 @@
   }
 
   .hero__company-text {
+    gap: 2.13vmin;
+  }
+
+  .hero__company-text hgroup {
     gap: 2.13vmin;
   }
 

--- a/src/widgets/hero/styles/Hero.css
+++ b/src/widgets/hero/styles/Hero.css
@@ -120,7 +120,7 @@
     content: '';
     display: block;
     order: 3;
-    height: calc(9.11vmin+ 4.56vmin);
+    height: calc(9.11vmin + 4.56vmin * 1.4);
   }
 
   .hero__logo {
@@ -169,7 +169,7 @@
     padding-top: 16vmin;
   }
   .hero__company::after {
-    height: calc(13.33vmin + 4.53vmin);
+    height: calc(13.33vmin + 4.53vmin * 1.4);
   }
 
   .hero__logo {

--- a/src/widgets/hero/styles/Hero.css
+++ b/src/widgets/hero/styles/Hero.css
@@ -28,9 +28,7 @@
 
 .hero__logo {
   height: 16.67vmax;
-  filter: drop-shadow(0 0 2.08vmax rgba(0, 0, 0, 1))
-    drop-shadow(0 0 1.04vmax rgba(0, 0, 0, 1))
-    drop-shadow(0 0 3.125vmax rgba(0, 0, 0, 1));
+  filter: drop-shadow(0 0 2.08vmax rgba(0, 0, 0, 1));
 }
 
 .hero__company-text {
@@ -39,10 +37,7 @@
   align-items: flex-end;
   white-space: nowrap;
   gap: 0.52vmax;
-  text-shadow:
-    0 0 2.08vmax rgba(0, 0, 0, 1),
-    0 0 1.04vmax rgba(0, 0, 0, 1),
-    0 0 3.125vmax rgba(0, 0, 0, 1);
+  text-shadow: 0 0 2.08vmax rgba(0, 0, 0, 1);
 }
 
 .hero__company-text hgroup {
@@ -103,9 +98,7 @@
   --size: 3.13vmax;
   width: var(--size);
   height: var(--size);
-  filter: drop-shadow(0 0 2.08vmax rgba(0, 0, 0, 1))
-    drop-shadow(0 0 1.04vmax rgba(0, 0, 0, 1))
-    drop-shadow(0 0 3.125vmax rgba(0, 0, 0, 1));
+  filter: drop-shadow(0 0 2.08vmax rgba(0, 0, 0, 1));
 }
 
 @media (max-width: 1024px) {
@@ -139,9 +132,7 @@
     order: 2;
     height: 37.5vmin;
     width: auto;
-    filter: drop-shadow(0 0 5.21vmin rgba(0, 0, 0, 1))
-      drop-shadow(0 0 2.6vmin rgba(0, 0, 0, 1))
-      drop-shadow(0 0 7.81vmin rgba(0, 0, 0, 1));
+    filter: drop-shadow(0 0 5.21vmin rgba(0, 0, 0, 1));
   }
 
   .hero__company-text {
@@ -150,10 +141,7 @@
     order: 1;
     align-items: center;
     gap: 1.82vmin;
-    text-shadow:
-      0 0 5.21vmin rgba(0, 0, 0, 1),
-      0 0 2.6vmin rgba(0, 0, 0, 1),
-      0 0 7.81vmin rgba(0, 0, 0, 1);
+    text-shadow: 0 0 5.21vmin rgba(0, 0, 0, 1);
   }
 
   .hero__company-text hgroup {
@@ -182,9 +170,7 @@
     --size: 6.51vmin;
     width: var(--size);
     height: var(--size);
-    filter: drop-shadow(0 0 5.21vmin rgba(0, 0, 0, 1))
-      drop-shadow(0 0 2.6vmin rgba(0, 0, 0, 1))
-      drop-shadow(0 0 7.81vmin rgba(0, 0, 0, 1));
+    filter: drop-shadow(0 0 5.21vmin rgba(0, 0, 0, 1));
   }
 }
 
@@ -198,17 +184,12 @@
 
   .hero__logo {
     height: 54.13vmin;
-    filter: drop-shadow(0 0 10.67vmin rgba(0, 0, 0, 1))
-      drop-shadow(0 0 5.33vmin rgba(0, 0, 0, 1))
-      drop-shadow(0 0 16vmin rgba(0, 0, 0, 1));
+    filter: drop-shadow(0 0 10.67vmin rgba(0, 0, 0, 1));
   }
 
   .hero__company-text {
     gap: 2.13vmin;
-    text-shadow:
-      0 0 10.67vmin rgba(0, 0, 0, 1),
-      0 0 5.33vmin rgba(0, 0, 0, 1),
-      0 0 16vmin rgba(0, 0, 0, 1);
+    text-shadow: 0 0 10.67vmin rgba(0, 0, 0, 1);
   }
 
   .hero__company-text hgroup {
@@ -233,8 +214,6 @@
     --size: 10.93vmin;
     width: var(--size);
     height: var(--size);
-    filter: drop-shadow(0 0 10.67vmin rgba(0, 0, 0, 1))
-      drop-shadow(0 0 5.33vmin rgba(0, 0, 0, 1))
-      drop-shadow(0 0 16vmin rgba(0, 0, 0, 1));
+    filter: drop-shadow(0 0 10.67vmin rgba(0, 0, 0, 1));
   }
 }

--- a/src/widgets/hero/ui/Hero.test.tsx
+++ b/src/widgets/hero/ui/Hero.test.tsx
@@ -25,6 +25,14 @@ describe('Hero', () => {
       expect(logo.getAttribute('src')).not.toBe('');
     });
 
+    it('로고 이미지에 hero__logo 클래스가 적용된다', () => {
+      render(<Hero />);
+
+      expect(screen.getByAltText('인들이앤에이치 로고')).toHaveClass(
+        'hero__logo',
+      );
+    });
+
     it('회사 한글 이름이 h1 요소로 표시된다', () => {
       render(<Hero />);
 
@@ -63,6 +71,23 @@ describe('Hero', () => {
       const { container } = render(<Hero />);
 
       expect(container.querySelector('canvas')).toBeInTheDocument();
+    });
+
+    it('회사명과 영문명이 hgroup으로 묶인다', () => {
+      const { container } = render(<Hero />);
+
+      const hgroup = container.querySelector('hgroup');
+      expect(hgroup).toBeInTheDocument();
+      expect(hgroup?.querySelector('h1')).toBeInTheDocument();
+      expect(hgroup?.querySelector('p')).toBeInTheDocument();
+    });
+
+    it('설립일 time 요소는 hgroup 밖에 위치한다', () => {
+      const { container } = render(<Hero />);
+
+      const hgroup = container.querySelector('hgroup');
+      expect(hgroup?.querySelector('time')).not.toBeInTheDocument();
+      expect(container.querySelector('time')).toBeInTheDocument();
     });
   });
 

--- a/src/widgets/hero/ui/Hero.tsx
+++ b/src/widgets/hero/ui/Hero.tsx
@@ -4,12 +4,9 @@ import { COMPANY } from '@shared/constant';
 
 import induelIcon from '@assets/induel-icon.svg';
 
+import { showScrollArrow } from '../model/heroConfig';
 import '../styles/Hero.css';
 import HeroBackground from './HeroBackground';
-
-const showDownIcon =
-  import.meta.env.MODE === 'production' ||
-  import.meta.env.VITE_SHOW_DOWN_ICON === 'true';
 
 function Hero() {
   return (
@@ -29,7 +26,7 @@ function Hero() {
           </time>
         </div>
       </div>
-      {showDownIcon ? (
+      {showScrollArrow ? (
         <IoIosArrowDown className='hero__down-icon' aria-hidden='true' />
       ) : (
         <p

--- a/src/widgets/hero/ui/Hero.tsx
+++ b/src/widgets/hero/ui/Hero.tsx
@@ -7,7 +7,9 @@ import induelIcon from '@assets/induel-icon.svg';
 import '../styles/Hero.css';
 import HeroBackground from './HeroBackground';
 
-const isProd = import.meta.env.MODE === 'production';
+const showDownIcon =
+  import.meta.env.MODE === 'production' ||
+  import.meta.env.VITE_SHOW_DOWN_ICON === 'true';
 
 function Hero() {
   return (
@@ -27,7 +29,7 @@ function Hero() {
           </time>
         </div>
       </div>
-      {isProd ? (
+      {showDownIcon ? (
         <IoIosArrowDown className='hero__down-icon' aria-hidden='true' />
       ) : (
         <p

--- a/src/widgets/hero/ui/Hero.tsx
+++ b/src/widgets/hero/ui/Hero.tsx
@@ -19,8 +19,10 @@ function Hero() {
           className='hero__logo'
         />
         <div className='hero__company-text'>
-          <h1 className='hero__company-name'>(주) {COMPANY.NAME_KO}</h1>
-          <p className='hero__company-name-en'>{COMPANY.NAME_EN_FULL}</p>
+          <hgroup>
+            <h1 className='hero__company-name'>(주) {COMPANY.NAME_KO}</h1>
+            <p className='hero__company-name-en'>{COMPANY.NAME_EN_FULL}</p>
+          </hgroup>
           <time className='hero__established' dateTime={COMPANY.ESTABLISHED}>
             SINCE {COMPANY.ESTABLISHED_DISPLAY}
           </time>

--- a/src/widgets/hero/ui/HeroBackground.test.tsx
+++ b/src/widgets/hero/ui/HeroBackground.test.tsx
@@ -1,212 +1,31 @@
 import { render } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import HeroBackground from './HeroBackground';
 
-// Three.js 유틸리티 mock — jsdom은 WebGL을 지원하지 않음
-const mockStopAnimation = vi.hoisted(() => vi.fn());
-const mockDetachResize = vi.hoisted(() => vi.fn());
-const mockDispose = vi.hoisted(() => vi.fn());
-const mockSceneAdd = vi.hoisted(() => vi.fn());
-const mockScene = vi.hoisted(() => ({ add: mockSceneAdd }));
-const mockCamera = vi.hoisted(() => ({}));
-const mockRenderer = vi.hoisted(() => ({ dispose: mockDispose }));
-const mockGroup = vi.hoisted(() => ({}));
-const mockTubes = vi.hoisted(() => [] as unknown[]);
-
-const mockStartWaveAnimation = vi.hoisted(() => vi.fn(() => mockStopAnimation));
-const mockCreateCamera = vi.hoisted(() => vi.fn(() => mockCamera));
-const mockCreateLights = vi.hoisted(() => vi.fn());
-const mockCreateRenderer = vi.hoisted(() => vi.fn(() => mockRenderer));
-const mockCreateScene = vi.hoisted(() => vi.fn(() => mockScene));
-const mockCreateWaveTubes = vi.hoisted(() =>
-  vi.fn(() => ({ group: mockGroup, tubes: mockTubes })),
-);
-const mockAttachResizeHandler = vi.hoisted(() => vi.fn(() => mockDetachResize));
-
-vi.mock('@shared/lib/three/animation/waveAnimation', () => ({
-  startWaveAnimation: mockStartWaveAnimation,
-}));
-vi.mock('@shared/lib/three/core/createCamera', () => ({
-  createCamera: mockCreateCamera,
-}));
-vi.mock('@shared/lib/three/core/createLights', () => ({
-  createLights: mockCreateLights,
-}));
-vi.mock('@shared/lib/three/core/createRenderer', () => ({
-  createRenderer: mockCreateRenderer,
-}));
-vi.mock('@shared/lib/three/core/createScene', () => ({
-  createScene: mockCreateScene,
-}));
-vi.mock('@shared/lib/three/objects/createWaveTubes', () => ({
-  createWaveTubes: mockCreateWaveTubes,
-}));
-vi.mock('@shared/lib/three/utils/attachResizeHandler', () => ({
-  attachResizeHandler: mockAttachResizeHandler,
+vi.mock('../model/useWaveBackground', () => ({
+  useWaveBackground: vi.fn(() => ({ current: null })),
 }));
 
 describe('HeroBackground', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+  it('canvas 엘리먼트가 렌더링된다', () => {
+    const { container } = render(<HeroBackground />);
+
+    expect(container.querySelector('canvas')).toBeInTheDocument();
   });
 
-  describe('canvas 렌더링', () => {
-    it('canvas 엘리먼트가 렌더링된다', () => {
-      const { container } = render(<HeroBackground />);
+  it('canvas에 hero__background 클래스가 적용된다', () => {
+    const { container } = render(<HeroBackground />);
 
-      expect(container.querySelector('canvas')).toBeInTheDocument();
-    });
-
-    it('canvas에 hero__background 클래스가 적용된다', () => {
-      const { container } = render(<HeroBackground />);
-
-      expect(container.querySelector('canvas')).toHaveClass('hero__background');
-    });
-
-    it('canvas는 스크린 리더에서 숨겨진다', () => {
-      const { container } = render(<HeroBackground />);
-
-      expect(container.querySelector('canvas')).toHaveAttribute(
-        'aria-hidden',
-        'true',
-      );
-    });
+    expect(container.querySelector('canvas')).toHaveClass('hero__background');
   });
 
-  describe('Three.js 초기화 파이프라인', () => {
-    it('마운트 시 Three.js 초기화 함수들이 호출된다', () => {
-      render(<HeroBackground />);
+  it('canvas는 스크린 리더에서 숨겨진다', () => {
+    const { container } = render(<HeroBackground />);
 
-      expect(mockCreateScene).toHaveBeenCalledOnce();
-      expect(mockCreateCamera).toHaveBeenCalledOnce();
-      expect(mockCreateRenderer).toHaveBeenCalledOnce();
-      expect(mockCreateLights).toHaveBeenCalledOnce();
-      expect(mockCreateWaveTubes).toHaveBeenCalledOnce();
-    });
-
-    it('createRenderer에 canvas 엘리먼트가 전달된다', () => {
-      const { container } = render(<HeroBackground />);
-
-      const canvas = container.querySelector('canvas');
-      expect(mockCreateRenderer).toHaveBeenCalledWith(canvas);
-    });
-
-    it('createLights에 scene이 전달된다', () => {
-      render(<HeroBackground />);
-
-      expect(mockCreateLights).toHaveBeenCalledWith(mockScene);
-    });
-
-    it('createWaveTubes에 scene이 전달된다', () => {
-      render(<HeroBackground />);
-
-      expect(mockCreateWaveTubes).toHaveBeenCalledWith(mockScene);
-    });
-
-    it('waveTubes의 group이 scene에 추가된다', () => {
-      render(<HeroBackground />);
-
-      expect(mockSceneAdd).toHaveBeenCalledWith(mockGroup);
-    });
-
-    it('startWaveAnimation에 올바른 인자가 전달된다', () => {
-      render(<HeroBackground />);
-
-      expect(mockStartWaveAnimation).toHaveBeenCalledWith(
-        mockRenderer,
-        mockScene,
-        mockCamera,
-        mockTubes,
-      );
-    });
-
-    it('attachResizeHandler에 camera와 renderer가 전달된다', () => {
-      render(<HeroBackground />);
-
-      expect(mockAttachResizeHandler).toHaveBeenCalledWith(
-        mockCamera,
-        mockRenderer,
-      );
-    });
-  });
-
-  describe('클린업 (언마운트)', () => {
-    it('언마운트 시 애니메이션이 정지된다', () => {
-      const { unmount } = render(<HeroBackground />);
-
-      unmount();
-
-      expect(mockStopAnimation).toHaveBeenCalledOnce();
-    });
-
-    it('언마운트 시 리사이즈 핸들러가 해제된다', () => {
-      const { unmount } = render(<HeroBackground />);
-
-      unmount();
-
-      expect(mockDetachResize).toHaveBeenCalledOnce();
-    });
-
-    it('언마운트 시 renderer가 해제된다', () => {
-      const { unmount } = render(<HeroBackground />);
-
-      unmount();
-
-      expect(mockDispose).toHaveBeenCalledOnce();
-    });
-  });
-
-  describe('Three.js 초기화 실패 시', () => {
-    it('createScene에서 에러 발생 시 cleanup 함수가 호출되지 않는다', () => {
-      mockCreateScene.mockImplementationOnce(() => {
-        throw new Error('WebGL not supported');
-      });
-
-      const { unmount } = render(<HeroBackground />);
-      unmount();
-
-      expect(mockStopAnimation).not.toHaveBeenCalled();
-      expect(mockDetachResize).not.toHaveBeenCalled();
-      expect(mockDispose).not.toHaveBeenCalled();
-    });
-
-    it('createRenderer에서 에러 발생 시 cleanup 함수가 호출되지 않는다', () => {
-      mockCreateRenderer.mockImplementationOnce(() => {
-        throw new Error('Canvas context creation failed');
-      });
-
-      const { unmount } = render(<HeroBackground />);
-      unmount();
-
-      expect(mockStopAnimation).not.toHaveBeenCalled();
-      expect(mockDetachResize).not.toHaveBeenCalled();
-      expect(mockDispose).not.toHaveBeenCalled();
-    });
-
-    it('createWaveTubes에서 에러 발생 시 이전에 생성된 리소스도 정리되지 않는다', () => {
-      mockCreateWaveTubes.mockImplementationOnce(() => {
-        throw new Error('Geometry creation failed');
-      });
-
-      const { unmount } = render(<HeroBackground />);
-      unmount();
-
-      // catch 블록에서 early return하므로 cleanup 함수가 등록되지 않음
-      expect(mockStopAnimation).not.toHaveBeenCalled();
-      expect(mockDetachResize).not.toHaveBeenCalled();
-      expect(mockDispose).not.toHaveBeenCalled();
-    });
-
-    it('초기화 실패해도 canvas는 정상 렌더링된다', () => {
-      mockCreateScene.mockImplementationOnce(() => {
-        throw new Error('WebGL not supported');
-      });
-
-      const { container } = render(<HeroBackground />);
-
-      expect(container.querySelector('canvas')).toBeInTheDocument();
-      expect(container.querySelector('canvas')).toHaveClass('hero__background');
-    });
+    expect(container.querySelector('canvas')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
   });
 });

--- a/src/widgets/hero/ui/HeroBackground.tsx
+++ b/src/widgets/hero/ui/HeroBackground.tsx
@@ -1,46 +1,7 @@
-import { useEffect, useRef } from 'react';
-
-import { startWaveAnimation } from '@shared/lib/three/animation/waveAnimation';
-import { createCamera } from '@shared/lib/three/core/createCamera';
-import { createLights } from '@shared/lib/three/core/createLights';
-import { createRenderer } from '@shared/lib/three/core/createRenderer';
-import { createScene } from '@shared/lib/three/core/createScene';
-import { createWaveTubes } from '@shared/lib/three/objects/createWaveTubes';
-import { attachResizeHandler } from '@shared/lib/three/utils/attachResizeHandler';
+import { useWaveBackground } from '../model/useWaveBackground';
 
 function HeroBackground() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-
-    let stopAnimation: (() => void) | undefined;
-    let detachResize: (() => void) | undefined;
-    let renderer: ReturnType<typeof createRenderer> | undefined;
-
-    try {
-      const scene = createScene();
-      const camera = createCamera();
-      renderer = createRenderer(canvas);
-
-      createLights(scene);
-
-      const { group, tubes } = createWaveTubes(scene);
-      scene.add(group);
-
-      stopAnimation = startWaveAnimation(renderer, scene, camera, tubes);
-      detachResize = attachResizeHandler(camera, renderer);
-    } catch {
-      return;
-    }
-
-    return () => {
-      stopAnimation?.();
-      detachResize?.();
-      renderer?.dispose();
-    };
-  }, []);
+  const canvasRef = useWaveBackground();
 
   return (
     <canvas ref={canvasRef} className='hero__background' aria-hidden='true' />


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- #73

### Three.js 애니메이션 루프 성능 병목 제거

- `computeVertexNormals()`가 매 프레임 모든 튜브에서 호출되어 초당 수백만 건의 법선 벡터 재연산이 발생
- 캔버스에 `filter: blur(10px)` CSS가 적용되어 있어 정확한 법선이 시각적으로 불필요함 → 제거
- `posAttr.getZ(i)`로 매 프레임 읽던 Z값을 `baseY`와 동일하게 `baseZ: Float32Array`로 캐싱
- resize 이벤트에 debounce 없이 `renderer.setSize()` 호출 → 100ms debounce 적용

### FSD 패턴에 따른 파일 구조 분리

- `HeroBackground.tsx`에 Three.js 씬 초기화 로직이 전부 포함되어 UI/Model 혼재
- `model/useWaveBackground.ts` 훅으로 추출 → `HeroBackground.tsx`는 canvas 렌더링만 담당
- 환경변수 기반 설정값(`showScrollArrow`)을 `model/heroConfig.ts`로 분리

### 핵심 변화

#### 변경 전

```
widgets/hero/
  ui/
    Hero.tsx          ← 인라인 env 체크
    HeroBackground.tsx ← Three.js 초기화 + canvas 렌더링 혼재
  styles/Hero.css
```

```ts
// HeroBackground.tsx — useEffect 내부에 씬 초기화 전체
useEffect(() => {
  const scene = createScene();
  ...
  for (...) {
    posAttr.setY(i, baseY[i] + Math.sin(posAttr.getZ(i) * WAVE_FREQ + ...));
  }
  geo.computeVertexNormals(); // 매 프레임 실행
  renderer.render(scene, camera);
}, []);
```

#### 변경 후

```
widgets/hero/
  model/
    heroConfig.ts       ← showScrollArrow 환경변수 설정
    useWaveBackground.ts ← Three.js 초기화 훅
  ui/
    Hero.tsx
    HeroBackground.tsx  ← canvasRef + canvas 반환만
  styles/Hero.css
```

```ts
// waveAnimation.ts — computeVertexNormals 제거, baseZ 캐시 사용
for (const { posAttr, baseY, baseZ } of tubes) {
  for (let i = 0; i < count; i++) {
    posAttr.setY(i, baseY[i] + Math.sin(baseZ[i] * WAVE_FREQ + ...));
  }
  posAttr.needsUpdate = true;
  // geo.computeVertexNormals() 제거
}
```

# 📋 작업 내용

- `computeVertexNormals()` 제거 — blur 처리된 캔버스에서 불필요한 연산 초당 ~190만 건 제거
- `baseZ: Float32Array` 캐싱 — 정적인 Z값의 매 프레임 BufferAttribute 읽기 제거
- `attachResizeHandler` 100ms debounce 적용 — WebGL context resize 호출 최소화
- `createWaveTubes(scene)` → `createWaveTubes()` — scene 추가 책임을 호출부로 이동, 중복 `scene.add` 제거
- `TubeData`에서 `geo: BufferGeometry` 필드 제거
- `model/useWaveBackground.ts` 신규 생성 — Three.js 초기화 로직 분리
- `model/heroConfig.ts` 신규 생성 — 환경변수 설정값 분리

# 📷 스크린 샷 (선택 사항)
`클라이언트 요청`

- 변경 후
    - Tablet
      <img width="761" height="894" alt="image" src="https://github.com/user-attachments/assets/4141f58f-1f33-4bbc-9c3f-92396419e4bd" />
    - Mobile
      <img width="374" height="676" alt="image" src="https://github.com/user-attachments/assets/541b2a6d-972a-4dae-83d7-d0abb21b66e5" />

- 변경 전
    - Tablet
      <img width="758" height="892" alt="image" src="https://github.com/user-attachments/assets/9c3578c7-d0fb-405e-bb4b-cf5f36c037d9" />
    - Mobile
      <img width="370" height="679" alt="image" src="https://github.com/user-attachments/assets/f2ce7179-b7af-4469-94c1-4cea2705e1bb" />
