### PR TITLE
✨ feat: Footer 컴포넌트 구현 및 반응형 적용

### DIFF
--- a/src/shared/constant/company.ts
+++ b/src/shared/constant/company.ts
@@ -1,7 +1,7 @@
 export const COMPANY = {
   NAME_KO: '인들이앤에이치',
   NAME_EN: 'INDUEL E&H',
-  NAME_EN_FULL: 'Induel Engineering & Holdings',
+  NAME_EN_FULL: 'INDUEL ENGINEERING & HOLDINGS',
   CEO: '이선학',
   BUSINESS_NO: '617-81-27655',
   PHONE: '0516266277',

--- a/src/widgets/footer/styles/Footer.css
+++ b/src/widgets/footer/styles/Footer.css
@@ -43,11 +43,6 @@
   row-gap: 0.26vw;
 }
 
-.footer__company-name-eng {
-  font-size: 1.04vw;
-  font-weight: 900;
-}
-
 .footer__company-name-kor {
   font-size: 0.83vw;
   font-weight: 800;
@@ -132,11 +127,6 @@
     row-gap: 0.65vw;
   }
 
-  /* 회사명 */
-  .footer__company-name-eng {
-    font-size: 2.344vw;
-  }
-
   .footer__company-name-kor {
     font-size: 1.823vw;
   }
@@ -205,10 +195,6 @@
   /* 회사이름 */
   .footer__company-name {
     row-gap: 1.041vw;
-  }
-
-  .footer__company-name-eng {
-    font-size: 3.13vw;
   }
 
   .footer__company-name-kor {

--- a/src/widgets/footer/styles/Footer.css
+++ b/src/widgets/footer/styles/Footer.css
@@ -89,7 +89,8 @@
   align-items: center;
 }
 
-.footer__left {
+.footer__left,
+.footer__right {
   display: flex;
   flex-direction: column;
   gap: 0.26vmax;
@@ -126,14 +127,143 @@
 }
 
 .footer__right {
-  display: flex;
-  flex-direction: column;
   align-items: flex-end;
-  gap: 0.26vmax;
 }
 
 .footer__copyright {
   font-weight: 100;
   font-size: 0.625vmax;
   color: var(--footer-copyright);
+}
+
+@media (max-width: 1024px) {
+  .footer {
+    height: 20vh;
+    padding: 2.6vmin 3.91vmin;
+  }
+
+  .footer__company {
+    gap: 1.95vmin;
+  }
+
+  .footer__icon-frame {
+    width: 4.69vmin;
+    height: 4.69vmin;
+    padding: 0.651vmin;
+    border-radius: 0.651vmin;
+  }
+
+  .footer__company_name-kor {
+    font-size: 2.08vmin;
+  }
+
+  .footer__company_name-eng {
+    font-size: 1.3vmin;
+  }
+
+  .footer__information {
+    gap: 3.26vmin;
+  }
+
+  .footer__information button {
+    font-size: 1.82vmin;
+  }
+
+  .footer hr {
+    border-top: 0.13vmin solid var(--footer-divider);
+  }
+
+  .footer__left,
+  .footer__right {
+    gap: 0.65vmin;
+  }
+
+  .footer__company_owner,
+  .footer__contact {
+    gap: 1.3vmin;
+  }
+
+  .footer__row {
+    gap: 1.3vmin;
+    font-size: 1.82vmin;
+  }
+
+  .footer__company_split {
+    font-size: 1.82vmin;
+  }
+
+  .footer__copyright {
+    font-size: 1.56vmin;
+  }
+}
+
+@media (max-width: 767px) {
+  .footer {
+    height: 23.53vh;
+    padding: 4vmin 4vmin;
+  }
+
+  .footer__company {
+    gap: 4vmin;
+  }
+
+  .footer__icon-frame {
+    width: 7.47vmin;
+    height: 7.47vmin;
+    padding: 1.33vmin;
+    border-radius: 1.33vmin;
+  }
+
+  .footer__company_name-kor {
+    font-size: 3.2vmin;
+  }
+
+  .footer__company_name-eng {
+    font-size: 2.13vmin;
+  }
+
+  .footer__information {
+    gap: 2.67vmin;
+  }
+
+  .footer__information button {
+    font-size: 2.67vmin;
+  }
+
+  .footer hr {
+    border-top: 0.267vmin solid var(--footer-divider);
+  }
+
+  .footer__content {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.33vmin;
+  }
+
+  .footer__left,
+  .footer__right {
+    gap: 1.33vmin;
+  }
+
+  .footer__right {
+    align-items: flex-start;
+  }
+
+  .footer__company_owner,
+  .footer__contact {
+    gap: 1.3vmin;
+  }
+
+  .footer__row {
+    gap: 2.67vmin;
+    font-size: 2.13vmin;
+  }
+
+  .footer__company_split {
+    font-size: 2.13vmin;
+  }
+
+  .footer__copyright {
+    font-size: 1.6vmin;
+  }
 }

--- a/src/widgets/footer/styles/Footer.css
+++ b/src/widgets/footer/styles/Footer.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 25.53vh;
+  height: 12.5vmax;
   align-items: center;
   justify-content: space-between;
   padding: 2.08vmax 10.42vmax;
@@ -138,7 +138,7 @@
 
 @media (max-width: 1024px) {
   .footer {
-    height: 20vh;
+    height: 23.44vmin;
     padding: 2.6vmin 3.91vmin;
   }
 
@@ -199,7 +199,7 @@
 
 @media (max-width: 767px) {
   .footer {
-    height: 23.53vh;
+    height: 42.67vmin;
     padding: 4vmin 4vmin;
   }
 

--- a/src/widgets/footer/styles/Footer.css
+++ b/src/widgets/footer/styles/Footer.css
@@ -1,237 +1,139 @@
 .footer {
+  display: flex;
+  flex-direction: column;
   width: 100%;
+  height: 25.53vh;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2.08vmax 10.42vmax;
   background-color: var(--footer-background);
-  color: var(--typo-titleW);
-  font-size: 0.73vw;
-  padding: 3.125vw 6.25vw;
-  text-align: left;
 }
 
 .footer__top {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: start;
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .footer__company {
-  justify-self: start;
   display: flex;
-  flex-direction: column;
-  row-gap: 1.094vw;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.781vmax;
 }
 
-.footer__contact {
-  justify-self: center;
-  text-align: left;
+.footer__icon-frame {
   display: flex;
-  flex-direction: column;
-  row-gap: 0.417vw;
+  width: 2.19vmax;
+  height: 2.19vmax;
+  justify-content: center;
+  align-items: center;
+  padding: 0.26vmax;
+  border-radius: 0.26vmax;
+  background-color: var(--white);
+  overflow: hidden;
 }
 
-.footer__address {
-  justify-self: end;
-  text-align: left;
-  display: flex;
-  flex-direction: column;
-  row-gap: 0.625vw;
+.footer__icon-frame img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
-/* 회사명 */
-.footer__company-name {
+.footer__company_name {
   display: flex;
   flex-direction: column;
-  row-gap: 0.26vw;
 }
 
-.footer__company-name-kor {
-  font-size: 0.83vw;
+.footer__company_name-kor {
   font-weight: 800;
-}
-
-.footer__company-name-full {
-  font-size: 0.73vw;
-  font-weight: 700;
-}
-
-.footer__company-owner {
-  display: flex;
-  flex-direction: column;
-  row-gap: 0.417vw;
-}
-
-.footer__company-row {
-  display: flex;
-  column-gap: 0.417vw;
-  font-weight: 600;
-}
-
-.footer__company-row span {
-  color: var(--footer-context);
-}
-
-/* 연락처, 이메일, 주소 */
-.footer__title {
-  font-size: 1.04vw;
-  font-weight: 900;
-}
-
-.footer__contact-row {
-  display: flex;
-  column-gap: 0.781vw;
-  font-weight: 600;
-}
-
-.footer__contact-row a {
-  text-decoration: none;
+  font-size: 0.938vmax;
   color: var(--white);
 }
 
-.footer__contact-row span {
-  color: var(--footer-context);
-}
-
-.footer__address span {
+.footer__company_name-eng {
   font-weight: 600;
+  font-size: 0.625vmax;
+  color: var(--gray-500);
 }
 
-/* footer bottom */
-.footer__bottom {
-  margin-top: 1.563vw;
+.footer__information {
+  display: flex;
+  flex-direction: row;
+  gap: 1.3vmax;
+}
+
+.footer__information button {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.729vmax;
+  color: var(--gray-500);
+}
+
+.footer__information b {
+  font-weight: 900;
 }
 
 .footer hr {
-  border: none;
-  border-top: 1px solid var(--footer-divider);
-  margin-bottom: 3.125vw;
+  width: 100%;
+  border-top: 0.052vmax solid var(--footer-divider);
 }
 
-.footer__bottom p {
-  text-align: center;
+.footer__content {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.footer__left {
+  display: flex;
+  flex-direction: column;
+  gap: 0.26vmax;
+}
+
+.footer__company_owner,
+.footer__contact {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.417vmax;
+}
+
+.footer__row {
+  display: flex;
+  flex-direction: row;
+  gap: 0.781vmax;
+  font-weight: 600;
+  font-size: 0.729vmax;
+}
+
+.footer__row span:first-child {
+  color: #d7d7d7;
+}
+
+.footer__row span:last-child {
+  color: var(--gray-500);
+}
+
+.footer__company_split {
+  font-weight: 600;
+  font-size: 0.729vmax;
+  color: var(--gray-500);
+}
+
+.footer__right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.26vmax;
+}
+
+.footer__copyright {
+  font-weight: 100;
+  font-size: 0.625vmax;
   color: var(--footer-copyright);
-  font-size: 0.65vw;
-}
-
-/* ========= 태블릿 ========= */
-@media (max-width: 1023px) {
-  .footer {
-    font-size: 1.302vw;
-    padding: 2.604vw 5.21vw;
-  }
-
-  .footer__company {
-    row-gap: 2.604vw;
-  }
-
-  .footer__contact,
-  .footer__address {
-    row-gap: 0.65vw;
-  }
-
-  .footer__company-name-kor {
-    font-size: 1.823vw;
-  }
-
-  .footer__company-name-full {
-    font-size: 1.563vw;
-  }
-
-  .footer__company-name,
-  .footer__company-owner {
-    row-gap: 0.651vw;
-  }
-
-  /* 연락처, 주소 */
-  .footer__title {
-    font-size: 1.823vw;
-  }
-
-  .footer__contact-row {
-    column-gap: 1.693vw;
-  }
-
-  /* footer bottom */
-  .footer__bottom {
-    margin-top: 1.56vw;
-  }
-
-  .footer hr {
-    margin-bottom: 2.604vw;
-  }
-
-  .footer__bottom p {
-    font-size: 1.302vw;
-  }
-}
-
-/* ========= 모바일 ========= */
-@media (max-width: 767px) {
-  .footer {
-    font-size: 2.08vw;
-    padding: 4.16vw;
-  }
-
-  /* footer top (grid 2*2) */
-  .footer__top {
-    display: grid;
-    grid-template-columns: repeat(2, auto);
-    grid-template-rows: repeat(2, auto);
-    align-items: start;
-    row-gap: 5.2vw;
-    column-gap: 22vw;
-  }
-
-  .footer__company {
-    grid-column: 1 / 2;
-    grid-row: 1 / 3;
-    row-gap: 2.5vw;
-  }
-
-  .footer__contact,
-  .footer__address {
-    justify-self: flex-start;
-    row-gap: 1.041vw;
-  }
-
-  /* 회사이름 */
-  .footer__company-name {
-    row-gap: 1.041vw;
-  }
-
-  .footer__company-name-kor {
-    font-size: 2.71vw;
-  }
-
-  .footer__company-name-full {
-    font-size: 2.5vw;
-  }
-
-  /* 대표자 정보 */
-  .footer__company-owner {
-    row-gap: 1.041vw;
-  }
-
-  .footer__company-row {
-    column-gap: 3.54vw;
-  }
-
-  /* Contact & Address */
-  .footer__title {
-    font-size: 2.5vw;
-  }
-
-  .footer__contact-row {
-    column-gap: 2.71vw;
-  }
-
-  /* footer bottom 부분 */
-  .footer__bottom {
-    margin-top: 2.5vw;
-  }
-  .footer hr {
-    margin-bottom: 4.17vw;
-  }
-
-  .footer__bottom p {
-    font-size: 2.08vw;
-  }
 }

--- a/src/widgets/footer/ui/Footer.test.tsx
+++ b/src/widgets/footer/ui/Footer.test.tsx
@@ -62,7 +62,36 @@ describe('Footer', () => {
   });
 
   describe('저작권 표시', () => {
-    it('저작권 문구에 회사 영문 풀네임이 포함된다', () => {
+    const foundedYear = new Date(COMPANY.ESTABLISHED).getFullYear();
+    const currentYear = new Date().getFullYear();
+
+    it('저작권 문구에 창립 연도가 포함된다', () => {
+      render(<Footer />);
+
+      expect(
+        screen.getByText((_, element) => {
+          return (
+            element?.tagName === 'P' &&
+            (element.textContent ?? '').includes(String(foundedYear))
+          );
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it('저작권 문구에 현재 연도가 포함된다', () => {
+      render(<Footer />);
+
+      expect(
+        screen.getByText((_, element) => {
+          return (
+            element?.tagName === 'P' &&
+            (element.textContent ?? '').includes(String(currentYear))
+          );
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it('저작권 문구에 회사 영문 풀네임과 All rights reserved가 포함된다', () => {
       render(<Footer />);
 
       expect(

--- a/src/widgets/footer/ui/Footer.test.tsx
+++ b/src/widgets/footer/ui/Footer.test.tsx
@@ -6,16 +6,10 @@ import { Footer } from './Footer';
 
 describe('Footer', () => {
   describe('회사 정보 표시', () => {
-    it('회사 영문 약칭이 표시된다', () => {
-      render(<Footer />);
-
-      expect(screen.getByText(COMPANY.NAME_EN)).toBeInTheDocument();
-    });
-
     it('회사 한글 이름이 표시된다', () => {
       render(<Footer />);
 
-      expect(screen.getByText(COMPANY.NAME_KO)).toBeInTheDocument();
+      expect(screen.getByText(`(주) ${COMPANY.NAME_KO}`)).toBeInTheDocument();
     });
 
     it('회사 영문 풀네임이 표시된다', () => {
@@ -46,13 +40,6 @@ describe('Footer', () => {
       expect(screen.getByText(COMPANY.PHONE_DISPLAY)).toBeInTheDocument();
     });
 
-    it('전화번호 링크가 tel: 프로토콜로 연결된다', () => {
-      render(<Footer />);
-
-      const telLink = screen.getByRole('link', { name: COMPANY.PHONE_DISPLAY });
-      expect(telLink).toHaveAttribute('href', `tel:${COMPANY.PHONE}`);
-    });
-
     it('팩스 번호가 표시된다', () => {
       render(<Footer />);
 
@@ -63,13 +50,6 @@ describe('Footer', () => {
       render(<Footer />);
 
       expect(screen.getByText(COMPANY.EMAIL)).toBeInTheDocument();
-    });
-
-    it('이메일 링크가 mailto: 프로토콜로 연결된다', () => {
-      render(<Footer />);
-
-      const mailLink = screen.getByRole('link', { name: COMPANY.EMAIL });
-      expect(mailLink).toHaveAttribute('href', `mailto:${COMPANY.EMAIL}`);
     });
   });
 
@@ -108,18 +88,6 @@ describe('Footer', () => {
       const { container } = render(<Footer />);
 
       expect(container.querySelector('footer')).toHaveClass('footer');
-    });
-
-    it('Contact 섹션 제목이 표시된다', () => {
-      render(<Footer />);
-
-      expect(screen.getByText('Contact')).toBeInTheDocument();
-    });
-
-    it('Address 섹션 제목이 표시된다', () => {
-      render(<Footer />);
-
-      expect(screen.getByText('Address')).toBeInTheDocument();
     });
   });
 });

--- a/src/widgets/footer/ui/Footer.tsx
+++ b/src/widgets/footer/ui/Footer.tsx
@@ -1,5 +1,7 @@
 import { COMPANY } from '@shared/constant';
 
+import induelIcon from '@assets/induel-icon.svg';
+
 import '../styles/Footer.css';
 
 export function Footer() {
@@ -7,53 +9,61 @@ export function Footer() {
     <footer className='footer'>
       <div className='footer__top'>
         <div className='footer__company'>
-          <div className='footer__company-name'>
-            <span className='footer__company-name-kor'>
-              (주) {COMPANY.NAME_KO}
-            </span>
-            <span className='footer__company-name-full'>
-              {COMPANY.NAME_EN_FULL}
-            </span>
+          <div className='footer__icon-frame'>
+            <img src={induelIcon} alt='인들이앤에이치 로고' />
           </div>
-
-          <address className='footer__company-owner'>
-            <div className='footer__company-row'>
-              <span>대표</span>
-              <p>{COMPANY.CEO}</p>
-            </div>
-            <div className='footer__company-row'>
-              <span>사업자 등록 번호</span>
-              <p>{COMPANY.BUSINESS_NO}</p>
-            </div>
-          </address>
+          <div className='footer__company_name'>
+            <p className='footer__company_name-kor'>(주) {COMPANY.NAME_KO}</p>
+            <p className='footer__company_name-eng'>{COMPANY.NAME_EN_FULL}</p>
+          </div>
         </div>
-
-        <address className='footer__contact'>
-          <span className='footer__title'>Contact</span>
-          <div className='footer__contact-row'>
-            <span>Tel</span>
-            <a href={`tel:${COMPANY.PHONE}`}>{COMPANY.PHONE_DISPLAY}</a>
-          </div>
-          <div className='footer__contact-row'>
-            <span>Fax</span>
-            <p>{COMPANY.FAX}</p>
-          </div>
-          <div className='footer__contact-row'>
-            <span>Email</span>
-            <a href={`mailto:${COMPANY.EMAIL}`}>{COMPANY.EMAIL}</a>
-          </div>
-        </address>
-
-        <address className='footer__address'>
-          <span className='footer__title'>Address</span>
-          <span>{COMPANY.ADDRESS_FULL}</span>
-        </address>
+        <div className='footer__information'>
+          <button>이용약관</button>
+          <button>
+            <b>개인정보처리방침</b>
+          </button>
+        </div>
       </div>
-
-      <div className='footer__bottom'>
-        <hr />
-        <p>© 2000-2026 {COMPANY.NAME_EN_FULL}. All rights reserved. </p>
+      <hr />
+      <div className='footer__content'>
+        <div className='footer__left'>
+          <div className='footer__company_owner'>
+            <div className='footer__row'>
+              <span>대표이사</span>
+              <span>{COMPANY.CEO}</span>
+            </div>
+            <p className='footer__company_split'>|</p>
+            <div className='footer__row'>
+              <span>사업자 등록 번호</span>
+              <span>{COMPANY.BUSINESS_NO}</span>
+            </div>
+          </div>
+          <div className='footer__row'>
+            <span>주소</span>
+            <span>{COMPANY.ADDRESS_FULL}</span>
+          </div>
+        </div>
+        <div className='footer__right'>
+          <div className='footer__contact'>
+            <div className='footer__row'>
+              <span>TEL</span>
+              <span>{COMPANY.PHONE_DISPLAY}</span>
+            </div>
+            <p className='footer__company_split'>|</p>
+            <div className='footer__row'>
+              <span>FAX</span>
+              <span>{COMPANY.FAX}</span>
+            </div>
+          </div>
+          <div className='footer__row'>
+            <span>EMAIL</span>
+            <span>{COMPANY.EMAIL}</span>
+          </div>
+        </div>
       </div>
+      <p className='footer__copyright'>
+        ⓒ 2000-2026 {COMPANY.NAME_EN_FULL}. All rights reserved.
+      </p>
     </footer>
   );
 }

--- a/src/widgets/footer/ui/Footer.tsx
+++ b/src/widgets/footer/ui/Footer.tsx
@@ -62,7 +62,8 @@ export function Footer() {
         </div>
       </div>
       <p className='footer__copyright'>
-        ⓒ 2000-2026 {COMPANY.NAME_EN_FULL}. All rights reserved.
+        ⓒ {new Date(COMPANY.ESTABLISHED).getFullYear()}-
+        {new Date().getFullYear()} {COMPANY.NAME_EN_FULL}. All rights reserved.
       </p>
     </footer>
   );

--- a/src/widgets/footer/ui/Footer.tsx
+++ b/src/widgets/footer/ui/Footer.tsx
@@ -8,8 +8,9 @@ export function Footer() {
       <div className='footer__top'>
         <div className='footer__company'>
           <div className='footer__company-name'>
-            <span className='footer__company-name-eng'>{COMPANY.NAME_EN}</span>
-            <span className='footer__company-name-kor'>{COMPANY.NAME_KO}</span>
+            <span className='footer__company-name-kor'>
+              (주) {COMPANY.NAME_KO}
+            </span>
             <span className='footer__company-name-full'>
               {COMPANY.NAME_EN_FULL}
             </span>


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #14

### Footer 재구현

- 기존 Footer 컴포넌트를 디자인 변경에 맞춰 전면 재구현
- Desktop / Tablet / Mobile 세 가지 뷰포트 대응
- 반응형 배경 이슈 수정

### 핵심 변화

#### 변경 전
- 기존 디자인 기반의 Footer 레이아웃

#### 변경 후
- 변경된 디자인에 맞춘 Footer.tsx 재구현
- Tablet / Mobile 반응형 스타일 추가 (Footer.css)
- 영문 풀네임 상수 제거 (company.ts)
- Header.css 반응형 배경 수정
- 디자인 변경에 따른 Footer.test.tsx 테스트 코드 업데이트

# 📋 작업 내용

- `Footer.tsx` — 변경된 디자인에 맞춰 컴포넌트 전면 재구현
- `Footer.css` — Desktop · Tablet · Mobile 반응형 스타일 적용, 반응형 배경 수정
- `Footer.test.tsx` — 변경된 구조에 맞춰 테스트 코드 업데이트
- `Header.css` — 반응형 배경 렌더링 수정
- `company.ts` — 불필요한 영문 풀네임 상수 제거

# 📷 스크린 샷 (선택 사항)
- 변경 후
  - PC
    <img width="2543" height="316" alt="image" src="https://github.com/user-attachments/assets/cd26d4dc-c767-4820-a829-3c8a2b08bb54" />
  - Tablet
    <img width="765" height="187" alt="image" src="https://github.com/user-attachments/assets/bb611cfe-149c-40e3-8b75-b7504cb0241b" />
  - Mobile
    <img width="366" height="155" alt="image" src="https://github.com/user-attachments/assets/68604c69-d860-4af9-97d8-1478a0ee8ef3" />

- 변경 전
  - PC
    <img width="1521" height="300" alt="image" src="https://github.com/user-attachments/assets/192fbfac-30d4-4223-961c-eb0253a679d9" />  
  - Tablet
    <img width="763" height="213" alt="image" src="https://github.com/user-attachments/assets/9397a97e-fb81-4a93-a029-2ea504184971" />  
  - Mobile
    <img width="363" height="165" alt="image" src="https://github.com/user-attachments/assets/a91476ac-ea05-4e10-b503-5b4744b6e001" />  