### PR TITLE
✨ feat: 헤더 스크롤 시 숨김/표시 애니메이션 구현

### DIFF
--- a/src/widgets/header/model/useHeaderVisibility.test.ts
+++ b/src/widgets/header/model/useHeaderVisibility.test.ts
@@ -1,0 +1,148 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { useHeaderVisibility } from './useHeaderVisibility';
+
+describe('useHeaderVisibility', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'scrollY', {
+      writable: true,
+      configurable: true,
+      value: 0,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'scrollY', {
+      writable: true,
+      configurable: true,
+      value: 0,
+    });
+  });
+
+  describe('스크롤 동작', () => {
+    it('초기값은 hidden: false이다', () => {
+      const { result } = renderHook(() => useHeaderVisibility());
+      expect(result.current.hidden).toBe(false);
+    });
+
+    it('5px 초과 스크롤 다운 시 hidden: true가 된다', () => {
+      const { result } = renderHook(() => useHeaderVisibility());
+      act(() => {
+        Object.defineProperty(window, 'scrollY', {
+          value: 10,
+          configurable: true,
+        });
+        window.dispatchEvent(new Event('scroll'));
+      });
+      expect(result.current.hidden).toBe(true);
+    });
+
+    it('5px 미만 스크롤은 상태를 바꾸지 않는다', () => {
+      const { result } = renderHook(() => useHeaderVisibility());
+      act(() => {
+        Object.defineProperty(window, 'scrollY', {
+          value: 3,
+          configurable: true,
+        });
+        window.dispatchEvent(new Event('scroll'));
+      });
+      expect(result.current.hidden).toBe(false);
+    });
+
+    it('스크롤 다운 후 업 시 hidden: false가 된다', () => {
+      const { result } = renderHook(() => useHeaderVisibility());
+      act(() => {
+        Object.defineProperty(window, 'scrollY', {
+          value: 100,
+          configurable: true,
+        });
+        window.dispatchEvent(new Event('scroll'));
+      });
+      act(() => {
+        Object.defineProperty(window, 'scrollY', {
+          value: 80,
+          configurable: true,
+        });
+        window.dispatchEvent(new Event('scroll'));
+      });
+      expect(result.current.hidden).toBe(false);
+    });
+
+    it('scrollY가 0이면 항상 hidden: false이다', () => {
+      const { result } = renderHook(() => useHeaderVisibility());
+      act(() => {
+        Object.defineProperty(window, 'scrollY', {
+          value: 50,
+          configurable: true,
+        });
+        window.dispatchEvent(new Event('scroll'));
+      });
+      act(() => {
+        Object.defineProperty(window, 'scrollY', {
+          value: 0,
+          configurable: true,
+        });
+        window.dispatchEvent(new Event('scroll'));
+      });
+      expect(result.current.hidden).toBe(false);
+    });
+  });
+
+  describe('nav 스크롤 동작', () => {
+    it('onNavScrollStart 호출 시 hidden: true가 된다', () => {
+      const { result } = renderHook(() => useHeaderVisibility());
+      act(() => {
+        result.current.onNavScrollStart();
+      });
+      expect(result.current.hidden).toBe(true);
+    });
+
+    it('onNavScrollStart 이후 스크롤 업 이벤트가 와도 hidden이 유지된다', () => {
+      const { result } = renderHook(() => useHeaderVisibility());
+      act(() => {
+        Object.defineProperty(window, 'scrollY', {
+          value: 100,
+          configurable: true,
+        });
+        window.dispatchEvent(new Event('scroll'));
+      });
+      act(() => {
+        result.current.onNavScrollStart();
+      });
+      act(() => {
+        Object.defineProperty(window, 'scrollY', {
+          value: 50,
+          configurable: true,
+        });
+        window.dispatchEvent(new Event('scroll'));
+      });
+      expect(result.current.hidden).toBe(true);
+    });
+
+    it('onNavScrollEnd 이후 스크롤 업 이벤트 시 hidden: false가 된다', () => {
+      const { result } = renderHook(() => useHeaderVisibility());
+      act(() => {
+        Object.defineProperty(window, 'scrollY', {
+          value: 100,
+          configurable: true,
+        });
+        window.dispatchEvent(new Event('scroll'));
+      });
+      act(() => {
+        result.current.onNavScrollStart();
+      });
+      act(() => {
+        result.current.onNavScrollEnd();
+      });
+      act(() => {
+        Object.defineProperty(window, 'scrollY', {
+          value: 80,
+          configurable: true,
+        });
+        window.dispatchEvent(new Event('scroll'));
+      });
+      expect(result.current.hidden).toBe(false);
+    });
+  });
+});

--- a/src/widgets/header/model/useHeaderVisibility.ts
+++ b/src/widgets/header/model/useHeaderVisibility.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from 'react';
+
+const THRESHOLD = 5;
+
+export function useHeaderVisibility() {
+  const [hidden, setHidden] = useState(false);
+  const prevScrollY = useRef(0);
+  const navScrollActiveRef = useRef(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (navScrollActiveRef.current) return;
+
+      const currentScrollY = window.scrollY;
+
+      if (currentScrollY === 0) {
+        setHidden(false);
+        prevScrollY.current = 0;
+        return;
+      }
+
+      const diff = currentScrollY - prevScrollY.current;
+      if (Math.abs(diff) < THRESHOLD) return;
+
+      setHidden(diff > 0);
+      prevScrollY.current = currentScrollY;
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const onNavScrollStart = () => {
+    navScrollActiveRef.current = true;
+    setHidden(true);
+  };
+
+  const onNavScrollEnd = () => {
+    navScrollActiveRef.current = false;
+  };
+
+  return { hidden, onNavScrollStart, onNavScrollEnd };
+}

--- a/src/widgets/header/model/useScrollDirection.test.ts
+++ b/src/widgets/header/model/useScrollDirection.test.ts
@@ -1,0 +1,101 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { useScrollDirection } from './useScrollDirection';
+
+describe('useScrollDirection', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'scrollY', {
+      writable: true,
+      configurable: true,
+      value: 0,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'scrollY', {
+      writable: true,
+      configurable: true,
+      value: 0,
+    });
+  });
+
+  it('초기값은 up이다', () => {
+    const { result } = renderHook(() => useScrollDirection());
+    expect(result.current).toBe('up');
+  });
+
+  it('5px 초과 스크롤 다운 시 down을 반환한다', () => {
+    const { result } = renderHook(() => useScrollDirection());
+    act(() => {
+      Object.defineProperty(window, 'scrollY', {
+        value: 10,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(result.current).toBe('down');
+  });
+
+  it('5px 미만 스크롤은 방향을 바꾸지 않는다', () => {
+    const { result } = renderHook(() => useScrollDirection());
+    act(() => {
+      Object.defineProperty(window, 'scrollY', {
+        value: 3,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(result.current).toBe('up');
+  });
+
+  it('정확히 5px 스크롤은 방향을 바꾼다', () => {
+    const { result } = renderHook(() => useScrollDirection());
+    act(() => {
+      Object.defineProperty(window, 'scrollY', {
+        value: 5,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(result.current).toBe('down');
+  });
+
+  it('스크롤 다운 후 업 시 up을 반환한다', () => {
+    const { result } = renderHook(() => useScrollDirection());
+    act(() => {
+      Object.defineProperty(window, 'scrollY', {
+        value: 100,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event('scroll'));
+    });
+    act(() => {
+      Object.defineProperty(window, 'scrollY', {
+        value: 80,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(result.current).toBe('up');
+  });
+
+  it('scrollY가 0이면 항상 up이다', () => {
+    const { result } = renderHook(() => useScrollDirection());
+    act(() => {
+      Object.defineProperty(window, 'scrollY', {
+        value: 50,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event('scroll'));
+    });
+    act(() => {
+      Object.defineProperty(window, 'scrollY', {
+        value: 0,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(result.current).toBe('up');
+  });
+});

--- a/src/widgets/header/model/useScrollDirection.ts
+++ b/src/widgets/header/model/useScrollDirection.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from 'react';
+
+const THRESHOLD = 5;
+
+export function useScrollDirection(): 'up' | 'down' {
+  const [direction, setDirection] = useState<'up' | 'down'>('up');
+  const prevScrollY = useRef(0);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollY = window.scrollY;
+
+      if (currentScrollY === 0) {
+        setDirection('up');
+        prevScrollY.current = 0;
+        return;
+      }
+
+      const diff = currentScrollY - prevScrollY.current;
+
+      if (Math.abs(diff) < THRESHOLD) return;
+
+      setDirection(diff > 0 ? 'down' : 'up');
+      prevScrollY.current = currentScrollY;
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return direction;
+}

--- a/src/widgets/header/styles/Header.css
+++ b/src/widgets/header/styles/Header.css
@@ -12,6 +12,7 @@
   justify-content: space-between;
   background-color: #ffffff;
   transition:
+    transform 0.3s ease,
     background-color 0.3s ease,
     color 0.3s ease;
 }
@@ -22,6 +23,10 @@
 
 .header--hero.header--menu-open {
   background-color: #000000;
+}
+
+.header--hidden {
+  transform: translateY(-100%);
 }
 
 .header__logo {

--- a/src/widgets/header/ui/Header.test.tsx
+++ b/src/widgets/header/ui/Header.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Header } from './Header';
 
@@ -18,6 +18,20 @@ vi.mock('@shared/lib/scroll/smoothScrollTo', () => ({
 
 vi.mock('../model/useIsHero', () => ({
   useIsHero: mockUseIsHero,
+}));
+
+const mockOnNavScrollStart = vi.hoisted(() => vi.fn());
+const mockOnNavScrollEnd = vi.hoisted(() => vi.fn());
+const mockUseHeaderVisibility = vi.hoisted(() =>
+  vi.fn(() => ({
+    hidden: false,
+    onNavScrollStart: mockOnNavScrollStart,
+    onNavScrollEnd: mockOnNavScrollEnd,
+  })),
+);
+
+vi.mock('../model/useHeaderVisibility', () => ({
+  useHeaderVisibility: mockUseHeaderVisibility,
 }));
 
 describe('Header', () => {
@@ -64,6 +78,15 @@ describe('Header', () => {
   });
 
   describe('CSS 클래스', () => {
+    beforeEach(() => {
+      mockUseHeaderVisibility.mockReturnValue({
+        hidden: false,
+        onNavScrollStart: mockOnNavScrollStart,
+        onNavScrollEnd: mockOnNavScrollEnd,
+      });
+      mockUseIsHero.mockReturnValue(false);
+    });
+
     it('isHero가 true이면 header--hero 클래스가 적용된다', () => {
       mockUseIsHero.mockReturnValue(true);
       const { container } = render(<Header />);
@@ -71,9 +94,39 @@ describe('Header', () => {
     });
 
     it('isHero가 false이면 header--hero 클래스가 없다', () => {
-      mockUseIsHero.mockReturnValue(false);
       const { container } = render(<Header />);
       expect(container.querySelector('header')).not.toHaveClass('header--hero');
+    });
+
+    it('hidden이 true이면 header--hidden 클래스가 적용된다', () => {
+      mockUseHeaderVisibility.mockReturnValue({
+        hidden: true,
+        onNavScrollStart: mockOnNavScrollStart,
+        onNavScrollEnd: mockOnNavScrollEnd,
+      });
+      const { container } = render(<Header />);
+      expect(container.querySelector('header')).toHaveClass('header--hidden');
+    });
+
+    it('hidden이 false이면 header--hidden 클래스가 없다', () => {
+      const { container } = render(<Header />);
+      expect(container.querySelector('header')).not.toHaveClass(
+        'header--hidden',
+      );
+    });
+
+    it('모바일 메뉴가 열려있으면 hidden이 true여도 header--hidden 클래스가 적용되지 않는다', () => {
+      mockUseIsHero.mockReturnValue(true);
+      mockUseHeaderVisibility.mockReturnValue({
+        hidden: true,
+        onNavScrollStart: mockOnNavScrollStart,
+        onNavScrollEnd: mockOnNavScrollEnd,
+      });
+      const { container } = render(<Header />);
+      fireEvent.click(screen.getByRole('button', { name: '메뉴 열기' }));
+      expect(container.querySelector('header')).not.toHaveClass(
+        'header--hidden',
+      );
     });
   });
 
@@ -121,6 +174,48 @@ describe('Header', () => {
       expect(container.querySelector('header')).toHaveClass(
         'header--menu-open',
       );
+    });
+  });
+
+  describe('nav 클릭 후 헤더 숨김', () => {
+    beforeEach(() => {
+      mockOnNavScrollStart.mockClear();
+      mockOnNavScrollEnd.mockClear();
+      mockUseHeaderVisibility.mockReturnValue({
+        hidden: false,
+        onNavScrollStart: mockOnNavScrollStart,
+        onNavScrollEnd: mockOnNavScrollEnd,
+      });
+      mockUseIsHero.mockReturnValue(false);
+    });
+
+    it('nav 버튼 클릭 시 onNavScrollStart가 호출된다', () => {
+      render(<Header />);
+      fireEvent.click(screen.getAllByText('VISION')[0]);
+      expect(mockOnNavScrollStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('로고 버튼 클릭 시 onNavScrollStart가 호출된다', () => {
+      render(<Header />);
+      fireEvent.click(
+        screen.getByRole('button', { name: /인들이앤에이치 로고/ }),
+      );
+      expect(mockOnNavScrollStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('smoothScrollTo onDone 콜백에서 onNavScrollEnd가 호출된다', () => {
+      render(<Header />);
+      fireEvent.click(screen.getAllByText('VISION')[0]);
+
+      const [, onDone] = mockSmoothScrollTo.mock.calls.at(-1) as [
+        string,
+        () => void,
+      ];
+      act(() => {
+        onDone();
+      });
+
+      expect(mockOnNavScrollEnd).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -6,20 +6,33 @@ import { smoothScrollTo } from '@shared/lib/scroll/smoothScrollTo';
 import induelIcon from '@assets/induel-icon.svg';
 
 import { NAV_ITEMS } from '../model/navItems';
+import { useHeaderVisibility } from '../model/useHeaderVisibility';
 import { useIsHero } from '../model/useIsHero';
 import '../styles/Header.css';
 
 export function Header() {
   const isHero = useIsHero();
+  const { hidden, onNavScrollStart, onNavScrollEnd } = useHeaderVisibility();
   const [menuOpen, setMenuOpen] = useState(false);
 
   const scrollTo = (selector: string) => {
-    smoothScrollTo(selector, () => setMenuOpen(false));
+    onNavScrollStart();
+    smoothScrollTo(selector, () => {
+      setMenuOpen(false);
+      onNavScrollEnd();
+    });
   };
 
   return (
     <header
-      className={`header${isHero ? ' header--hero' : ''}${menuOpen && isHero ? ' header--menu-open' : ''}`}
+      className={[
+        'header',
+        isHero ? 'header--hero' : '',
+        hidden && !menuOpen ? 'header--hidden' : '',
+        menuOpen && isHero ? 'header--menu-open' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
     >
       <button className='header__logo' onClick={() => scrollTo('.hero')}>
         <div className='header__logo_icon-frame'>


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- #105

### 헤더 스크롤 동작 구현

스크롤 방향에 따라 헤더가 자동으로 숨겨지고 표시되는 동작을 구현했습니다.

- 스크롤 다운 시 헤더를 숨기고, 스크롤 업 시 다시 표시하는 UX를 추가하여 콘텐츠 가독성을 개선
- 내비게이션 클릭으로 섹션 이동 시에도 동일하게 헤더가 숨겨지도록 처리
- `useEffect` 내 `setState` 직접 호출 lint 오류 해결을 위해 `useHeaderVisibility` 훅으로 로직 통합

### 핵심 변화

#### 변경 전

- 헤더가 항상 고정 표시
- nav 버튼으로 위 섹션 이동 시 헤더가 사라지지 않음

#### 변경 후

- 스크롤 다운 → 헤더 `translateY(-100%)` 슬라이드 업 애니메이션으로 숨김
- 스크롤 업 → 헤더 슬라이드 다운으로 표시
- 스크롤 멈춤 → 현재 상태 유지
- nav / 로고 클릭 → 이동 방향 무관하게 헤더 숨김, 이후 수동 스크롤 업 시 복원
- 모바일 메뉴 열린 상태에서는 스크롤 다운해도 헤더 유지

# 📋 작업 내용

- `useScrollDirection.ts` — 스크롤 방향 감지 커스텀 훅 (5px threshold, scrollY=0 리셋)
- `useHeaderVisibility.ts` — 스크롤 방향 추적 + nav 클릭 오버라이드 통합 훅
- `Header.css` — `transform` transition 추가 및 `.header--hidden` 클래스 추가
- `Header.tsx` — `useHeaderVisibility` 연결, 메뉴 열림 시 숨김 방지 처리
- 각 훅 및 컴포넌트 테스트 추가 (336개 전체 통과)

# 📷 스크린 샷 (선택 사항)

동작 화면 첨부