### PR TITLE
📝 docs: award story book 작성

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -24,7 +24,7 @@ const preview: Preview = {
         },
         mobile: {
           name: 'Mobile (375px)',
-          styles: { width: '375px', height: '600px' },
+          styles: { width: '375px', height: '680px' },
           type: 'mobile',
         },
       },

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,6 +3,7 @@ import type { Preview } from '@storybook/react-vite';
 import '../src/app/styles/index.css';
 
 const preview: Preview = {
+  tags: ['autodocs'],
   parameters: {
     controls: {
       matchers: {

--- a/src/features/award/ui/Pagination.stories.tsx
+++ b/src/features/award/ui/Pagination.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { Pagination } from './Pagination';
+
+const meta = {
+  title: 'Features/Award/Pagination',
+  component: Pagination,
+  args: {
+    currentPage: 0,
+    totalPages: 5,
+    onPageChange: fn(),
+  },
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Award 위젯의 페이지네이션 컴포넌트. 현재 페이지와 총 페이지 수를 표시하며, 페이지 변경 시 onPageChange 콜백을 호출합니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof Pagination>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '기본',
+  parameters: {
+    docs: {
+      description: {
+        story: '현재 페이지 0, 총 페이지 5인 기본 상태.',
+      },
+    },
+  },
+};
+
+export const MiddlePage: Story = {
+  name: '중간 페이지',
+  args: {
+    currentPage: 2,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '현재 페이지 2로 설정하여 중간 페이지 상태를 시뮬레이션.',
+      },
+    },
+  },
+};
+
+export const LastPage: Story = {
+  name: '마지막 페이지',
+  args: {
+    currentPage: 4,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '현재 페이지 4로 설정하여 마지막 페이지 상태를 시뮬레이션.',
+      },
+    },
+  },
+};

--- a/src/features/award/ui/YearCategory.stories.tsx
+++ b/src/features/award/ui/YearCategory.stories.tsx
@@ -6,6 +6,11 @@ import { YearCategory } from './YearCategory';
 const meta = {
   title: 'Features/Award/YearCategory',
   component: YearCategory,
+  args: {
+    yearList: YEAR_LIST,
+    activeYear: '전체',
+    onYearChange: () => {},
+  },
   parameters: {
     layout: 'centered',
     docs: {
@@ -22,11 +27,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   name: '기본',
-  args: {
-    yearList: YEAR_LIST,
-    activeYear: '전체',
-    onYearChange: () => {},
-  },
   parameters: {
     docs: {
       description: {
@@ -40,9 +40,7 @@ export const Default: Story = {
 export const SelectedYear: Story = {
   name: '선택된 연도',
   args: {
-    yearList: YEAR_LIST,
     activeYear: YEAR_LIST[1],
-    onYearChange: () => {},
   },
   parameters: {
     docs: {

--- a/src/features/award/ui/YearCategory.stories.tsx
+++ b/src/features/award/ui/YearCategory.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { YEAR_LIST } from '../model/constant';
+import { YearCategory } from './YearCategory';
+
+const meta = {
+  title: 'Features/Award/YearCategory',
+  component: YearCategory,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Award 위젯의 연도 카테고리 컴포넌트. 연도별로 수상 기록을 필터링하는 역할을 합니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof YearCategory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '기본',
+  args: {
+    yearList: YEAR_LIST,
+    activeYear: '전체',
+    onYearChange: () => {},
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '전체 연도가 선택된 상태를 시뮬레이션하여 모든 수상 기록이 표시됩니다.',
+      },
+    },
+  },
+};
+
+export const SelectedYear: Story = {
+  name: '선택된 연도',
+  args: {
+    yearList: YEAR_LIST,
+    activeYear: YEAR_LIST[1],
+    onYearChange: () => {},
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '2020년이 선택된 상태를 시뮬레이션하여 해당 연도의 수상 기록이 필터링됩니다.',
+      },
+    },
+  },
+};

--- a/src/widgets/award/ui/Award.stories.tsx
+++ b/src/widgets/award/ui/Award.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import Award from './Award';
+
+const meta = {
+  title: 'Widgets/Award',
+  component: Award,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Page 6에 위치하는 Award 위젯. 연도 필터, 카드 그리드, 페이지네이션, 팝업을 포함하는 수상 기록 섹션입니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof Award>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Desktop: Story = {
+  name: 'Desktop (1920px)',
+  globals: {
+    viewport: { value: 'desktop' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '1920px 데스크탑 해상도. 카드 5×2 레이아웃, 슬라이드 방식 페이지 전환.',
+      },
+    },
+  },
+};
+
+export const Tablet: Story = {
+  name: 'Tablet (768px)',
+  globals: {
+    viewport: { value: 'tablet' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '768px 태블릿 해상도. 카드 3×2 레이아웃.',
+      },
+    },
+  },
+};
+
+export const Mobile: Story = {
+  name: 'Mobile (375px)',
+  globals: {
+    viewport: { value: 'mobile' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '375px 모바일 해상도. 카드 2×2 레이아웃, 하단 dot 페이지네이션 표시.',
+      },
+    },
+  },
+};

--- a/src/widgets/award/ui/Award.stories.tsx
+++ b/src/widgets/award/ui/Award.stories.tsx
@@ -19,45 +19,12 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Desktop: Story = {
-  name: 'Desktop (1920px)',
-  globals: {
-    viewport: { value: 'desktop' },
-  },
+export const Default: Story = {
+  name: 'Award 뷰포트',
   parameters: {
     docs: {
       description: {
-        story:
-          '1920px 데스크탑 해상도. 카드 5×2 레이아웃, 슬라이드 방식 페이지 전환.',
-      },
-    },
-  },
-};
-
-export const Tablet: Story = {
-  name: 'Tablet (768px)',
-  globals: {
-    viewport: { value: 'tablet' },
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: '768px 태블릿 해상도. 카드 3×2 레이아웃.',
-      },
-    },
-  },
-};
-
-export const Mobile: Story = {
-  name: 'Mobile (375px)',
-  globals: {
-    viewport: { value: 'mobile' },
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          '375px 모바일 해상도. 카드 2×2 레이아웃, 하단 dot 페이지네이션 표시.',
+        story: '카드 5×2 레이아웃, 슬라이드 방식 페이지 전환.',
       },
     },
   },

--- a/src/widgets/award/ui/Card.stories.tsx
+++ b/src/widgets/award/ui/Card.stories.tsx
@@ -24,15 +24,51 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  name: '기본',
+export const Desktop: Story = {
+  name: 'Desktop (1920px)',
   args: {
     award: AWARD_LIST[0],
+  },
+  globals: {
+    viewport: { value: 'desktop' },
   },
   parameters: {
     docs: {
       description: {
-        story: '일련번호(serialNumber)가 포함된 카드.',
+        story:
+          '1920px 데스크탑 해상도에서의 카드. 제목과 발급기관이 한 줄로 표시되고, 전체적으로 여유로운 레이아웃을 가집니다.',
+      },
+    },
+  },
+};
+
+export const Tablet: Story = {
+  name: 'Tablet (768px)',
+  args: { award: AWARD_LIST[0] },
+  globals: {
+    viewport: { value: 'tablet' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '768px 태블릿 해상도에서의 카드. 제목과 발급기관이 한 줄로 표시되지만, 데스크탑보다 좁은 레이아웃으로 약간 더 컴팩트하게 보입니다.',
+      },
+    },
+  },
+};
+
+export const Mobile: Story = {
+  name: 'Mobile (375px)',
+  args: { award: AWARD_LIST[0] },
+  globals: {
+    viewport: { value: 'mobile' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '375px 모바일 해상도에서의 카드. 제목과 발급기관이 두 줄로 표시되어 가독성을 유지하며, 전체적으로 컴팩트한 레이아웃을 가집니다.',
       },
     },
   },

--- a/src/widgets/award/ui/Card.stories.tsx
+++ b/src/widgets/award/ui/Card.stories.tsx
@@ -1,0 +1,39 @@
+import { AWARD_LIST } from '@entities/award';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { Card } from './Card';
+
+const meta = {
+  title: 'Widgets/Award/Card',
+  component: Card,
+  args: {
+    onClick: fn(),
+  },
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '개별 수상 항목을 나타내는 카드 컴포넌트. 연도, 제목, 발급기관을 표시하며 클릭 시 상세 팝업을 엽니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '기본',
+  args: {
+    award: AWARD_LIST[0],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '일련번호(serialNumber)가 포함된 카드.',
+      },
+    },
+  },
+};

--- a/src/widgets/award/ui/Card.stories.tsx
+++ b/src/widgets/award/ui/Card.stories.tsx
@@ -9,6 +9,7 @@ const meta = {
   component: Card,
   args: {
     onClick: fn(),
+    award: AWARD_LIST[0],
   },
   parameters: {
     layout: 'centered',
@@ -26,9 +27,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   name: 'Award Card',
-  args: {
-    award: AWARD_LIST[0],
-  },
   parameters: {
     docs: {
       description: {

--- a/src/widgets/award/ui/Card.stories.tsx
+++ b/src/widgets/award/ui/Card.stories.tsx
@@ -24,51 +24,16 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Desktop: Story = {
-  name: 'Desktop (1920px)',
+export const Default: Story = {
+  name: 'Award Card',
   args: {
     award: AWARD_LIST[0],
   },
-  globals: {
-    viewport: { value: 'desktop' },
-  },
   parameters: {
     docs: {
       description: {
         story:
-          '1920px 데스크탑 해상도에서의 카드. 제목과 발급기관이 한 줄로 표시되고, 전체적으로 여유로운 레이아웃을 가집니다.',
-      },
-    },
-  },
-};
-
-export const Tablet: Story = {
-  name: 'Tablet (768px)',
-  args: { award: AWARD_LIST[0] },
-  globals: {
-    viewport: { value: 'tablet' },
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          '768px 태블릿 해상도에서의 카드. 제목과 발급기관이 한 줄로 표시되지만, 데스크탑보다 좁은 레이아웃으로 약간 더 컴팩트하게 보입니다.',
-      },
-    },
-  },
-};
-
-export const Mobile: Story = {
-  name: 'Mobile (375px)',
-  args: { award: AWARD_LIST[0] },
-  globals: {
-    viewport: { value: 'mobile' },
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          '375px 모바일 해상도에서의 카드. 제목과 발급기관이 두 줄로 표시되어 가독성을 유지하며, 전체적으로 컴팩트한 레이아웃을 가집니다.',
+          '카드. 제목과 발급기관이 한 줄로 표시되고, 전체적으로 여유로운 레이아웃을 가집니다.',
       },
     },
   },

--- a/src/widgets/award/ui/Count.stories.tsx
+++ b/src/widgets/award/ui/Count.stories.tsx
@@ -19,19 +19,15 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Desktop: Story = {
+export const Default: Story = {
   name: '기본 (10건)',
   args: {
     awardList: AWARD_LIST,
   },
-  globals: {
-    viewport: { value: 'desktop' },
-  },
   parameters: {
     docs: {
       description: {
-        story:
-          '1920px 데스크탑 해상도에서 총 수상 건수 10건이 아이콘과 함께 표시되는 모습.',
+        story: '총 수상 건수 10건이 아이콘과 함께 표시되는 모습.',
       },
     },
   },
@@ -42,49 +38,10 @@ export const Few: Story = {
   args: {
     awardList: AWARD_LIST.slice(0, 2),
   },
-  globals: {
-    viewport: { value: 'desktop' },
-  },
   parameters: {
     docs: {
       description: {
         story: '2건만 전달하여 숫자가 동적으로 반영되는지 검증.',
-      },
-    },
-  },
-};
-
-export const Tablet: Story = {
-  name: '태블릿 뷰포트',
-  args: {
-    awardList: AWARD_LIST,
-  },
-  globals: {
-    viewport: { value: 'tablet' },
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          '768px 태블릿 해상도에서 총 수상 건수 10건이 아이콘과 함께 표시되는 모습.',
-      },
-    },
-  },
-};
-
-export const Mobile: Story = {
-  name: '모바일 뷰포트',
-  args: {
-    awardList: AWARD_LIST,
-  },
-  globals: {
-    viewport: { value: 'mobile' },
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          '모바일 뷰포트에서도 동일한 컴포넌트가 정상적으로 렌더링되는지 확인.',
       },
     },
   },

--- a/src/widgets/award/ui/Count.stories.tsx
+++ b/src/widgets/award/ui/Count.stories.tsx
@@ -1,0 +1,48 @@
+import { AWARD_LIST } from '@entities/award';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { AwardCount } from './Count';
+
+const meta = {
+  title: 'Widgets/Award/Count',
+  component: AwardCount,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: '총 수상 건수를 아이콘과 함께 표시하는 컴포넌트.',
+      },
+    },
+  },
+} satisfies Meta<typeof AwardCount>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '기본 (10건)',
+  args: {
+    awardList: AWARD_LIST,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '전체 10건의 수상 목록을 전달한 기본 상태.',
+      },
+    },
+  },
+};
+
+export const Few: Story = {
+  name: '소수 (2건)',
+  args: {
+    awardList: [AWARD_LIST[0], AWARD_LIST[1]],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '2건만 전달하여 숫자가 동적으로 반영되는지 검증.',
+      },
+    },
+  },
+};

--- a/src/widgets/award/ui/Count.stories.tsx
+++ b/src/widgets/award/ui/Count.stories.tsx
@@ -6,6 +6,9 @@ import { AwardCount } from './Count';
 const meta = {
   title: 'Widgets/Award/Count',
   component: AwardCount,
+  args: {
+    awardList: AWARD_LIST,
+  },
   parameters: {
     layout: 'centered',
     docs: {
@@ -21,9 +24,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   name: '기본 (10건)',
-  args: {
-    awardList: AWARD_LIST,
-  },
   parameters: {
     docs: {
       description: {

--- a/src/widgets/award/ui/Count.stories.tsx
+++ b/src/widgets/award/ui/Count.stories.tsx
@@ -19,15 +19,19 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Desktop: Story = {
   name: '기본 (10건)',
   args: {
     awardList: AWARD_LIST,
   },
+  globals: {
+    viewport: { value: 'desktop' },
+  },
   parameters: {
     docs: {
       description: {
-        story: '전체 10건의 수상 목록을 전달한 기본 상태.',
+        story:
+          '1920px 데스크탑 해상도에서 총 수상 건수 10건이 아이콘과 함께 표시되는 모습.',
       },
     },
   },
@@ -36,12 +40,51 @@ export const Default: Story = {
 export const Few: Story = {
   name: '소수 (2건)',
   args: {
-    awardList: [AWARD_LIST[0], AWARD_LIST[1]],
+    awardList: AWARD_LIST.slice(0, 2),
+  },
+  globals: {
+    viewport: { value: 'desktop' },
   },
   parameters: {
     docs: {
       description: {
         story: '2건만 전달하여 숫자가 동적으로 반영되는지 검증.',
+      },
+    },
+  },
+};
+
+export const Tablet: Story = {
+  name: '태블릿 뷰포트',
+  args: {
+    awardList: AWARD_LIST,
+  },
+  globals: {
+    viewport: { value: 'tablet' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '768px 태블릿 해상도에서 총 수상 건수 10건이 아이콘과 함께 표시되는 모습.',
+      },
+    },
+  },
+};
+
+export const Mobile: Story = {
+  name: '모바일 뷰포트',
+  args: {
+    awardList: AWARD_LIST,
+  },
+  globals: {
+    viewport: { value: 'mobile' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '모바일 뷰포트에서도 동일한 컴포넌트가 정상적으로 렌더링되는지 확인.',
       },
     },
   },

--- a/src/widgets/award/ui/Popup.stories.tsx
+++ b/src/widgets/award/ui/Popup.stories.tsx
@@ -23,29 +23,51 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Open: Story = {
-  name: '팝업 열림 (id=0)',
+export const Desktop: Story = {
+  name: 'Desktop 팝업 열림',
   args: {
     awardId: 0,
+  },
+  globals: {
+    viewport: { value: 'desktop' },
   },
   parameters: {
     docs: {
       description: {
-        story: 'awardId=0 이미지를 표시하는 팝업 열림 상태.',
+        story:
+          '1920px 데스크탑 해상도에서 팝업이 열렸을 때의 모습. 전체화면 오버레이로 수상 이미지가 표시되고, 닫기 버튼이 우측 상단에 위치합니다.',
       },
     },
   },
 };
 
-export const SecondAward: Story = {
-  name: '팝업 열림 (id=5)',
-  args: {
-    awardId: 5,
+export const Tablet: Story = {
+  name: 'Tablet 팝업 열림',
+  args: { awardId: 0 },
+  globals: {
+    viewport: { value: 'tablet' },
   },
   parameters: {
     docs: {
       description: {
-        story: 'awardId=5 이미지를 표시하는 팝업 열림 상태.',
+        story:
+          '768px 태블릿 해상도에서 팝업이 열렸을 때의 모습. 전체화면 오버레이로 수상 이미지가 표시되고, 닫기 버튼이 우측 상단에 위치합니다.',
+      },
+    },
+  },
+};
+
+export const Mobile: Story = {
+  name: 'Mobile 팝업 열림',
+  args: { awardId: 0 },
+  globals: {
+    viewport: { value: 'mobile' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '375px 모바일 해상도에서 팝업이 열렸을 때의 모습. 전체화면 오버레이로 수상 이미지가 표시되고, 닫기 버튼이 우측 상단에 위치합니다.',
       },
     },
   },

--- a/src/widgets/award/ui/Popup.stories.tsx
+++ b/src/widgets/award/ui/Popup.stories.tsx
@@ -8,6 +8,7 @@ const meta = {
   component: AwardPopup,
   args: {
     onClose: fn(),
+    awardId: 0,
   },
   parameters: {
     layout: 'fullscreen',
@@ -25,9 +26,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   name: '팝업 열림',
-  args: {
-    awardId: 0,
-  },
   parameters: {
     docs: {
       description: {

--- a/src/widgets/award/ui/Popup.stories.tsx
+++ b/src/widgets/award/ui/Popup.stories.tsx
@@ -23,51 +23,16 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Desktop: Story = {
-  name: 'Desktop 팝업 열림',
+export const Default: Story = {
+  name: '팝업 열림',
   args: {
     awardId: 0,
   },
-  globals: {
-    viewport: { value: 'desktop' },
-  },
   parameters: {
     docs: {
       description: {
         story:
-          '1920px 데스크탑 해상도에서 팝업이 열렸을 때의 모습. 전체화면 오버레이로 수상 이미지가 표시되고, 닫기 버튼이 우측 상단에 위치합니다.',
-      },
-    },
-  },
-};
-
-export const Tablet: Story = {
-  name: 'Tablet 팝업 열림',
-  args: { awardId: 0 },
-  globals: {
-    viewport: { value: 'tablet' },
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          '768px 태블릿 해상도에서 팝업이 열렸을 때의 모습. 전체화면 오버레이로 수상 이미지가 표시되고, 닫기 버튼이 우측 상단에 위치합니다.',
-      },
-    },
-  },
-};
-
-export const Mobile: Story = {
-  name: 'Mobile 팝업 열림',
-  args: { awardId: 0 },
-  globals: {
-    viewport: { value: 'mobile' },
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          '375px 모바일 해상도에서 팝업이 열렸을 때의 모습. 전체화면 오버레이로 수상 이미지가 표시되고, 닫기 버튼이 우측 상단에 위치합니다.',
+          '팝업이 열렸을 때의 모습. 전체화면 오버레이로 수상 이미지가 표시되고, 닫기 버튼이 우측 상단에 위치합니다.',
       },
     },
   },

--- a/src/widgets/award/ui/Popup.stories.tsx
+++ b/src/widgets/award/ui/Popup.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { AwardPopup } from './Popup';
+
+const meta = {
+  title: 'Widgets/Award/Popup',
+  component: AwardPopup,
+  args: {
+    onClose: fn(),
+  },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          '수상 카드 클릭 시 열리는 팝업. 해당 수상 이미지를 전체화면 오버레이로 표시하며, 닫기 버튼 또는 배경 클릭으로 닫힙니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof AwardPopup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Open: Story = {
+  name: '팝업 열림 (id=0)',
+  args: {
+    awardId: 0,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'awardId=0 이미지를 표시하는 팝업 열림 상태.',
+      },
+    },
+  },
+};
+
+export const SecondAward: Story = {
+  name: '팝업 열림 (id=5)',
+  args: {
+    awardId: 5,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'awardId=5 이미지를 표시하는 팝업 열림 상태.',
+      },
+    },
+  },
+};

--- a/src/widgets/award/ui/Title.stories.tsx
+++ b/src/widgets/award/ui/Title.stories.tsx
@@ -19,43 +19,12 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Desktop: Story = {
+export const Default: Story = {
   name: '기본',
-  globals: {
-    viewport: { value: 'desktop' },
-  },
   parameters: {
     docs: {
       description: {
-        story: '1920px 데스크탑 해상도에서 타이틀이 렌더링되는 모습.',
-      },
-    },
-  },
-};
-
-export const Tablet: Story = {
-  name: '태블릿 뷰포트',
-  globals: {
-    viewport: { value: 'tablet' },
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: '768px 태블릿 해상도에서 타이틀이 렌더링되는 모습.',
-      },
-    },
-  },
-};
-
-export const Mobile: Story = {
-  name: '모바일 뷰포트',
-  globals: {
-    viewport: { value: 'mobile' },
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: '768px 모바일 해상도에서 타이틀이 렌더링되는 모습.',
+        story: '타이틀이 렌더링되는 모습.',
       },
     },
   },

--- a/src/widgets/award/ui/Title.stories.tsx
+++ b/src/widgets/award/ui/Title.stories.tsx
@@ -19,12 +19,43 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Desktop: Story = {
   name: '기본',
+  globals: {
+    viewport: { value: 'desktop' },
+  },
   parameters: {
     docs: {
       description: {
-        story: 'props 없이 정적으로 렌더링되는 타이틀.',
+        story: '1920px 데스크탑 해상도에서 타이틀이 렌더링되는 모습.',
+      },
+    },
+  },
+};
+
+export const Tablet: Story = {
+  name: '태블릿 뷰포트',
+  globals: {
+    viewport: { value: 'tablet' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '768px 태블릿 해상도에서 타이틀이 렌더링되는 모습.',
+      },
+    },
+  },
+};
+
+export const Mobile: Story = {
+  name: '모바일 뷰포트',
+  globals: {
+    viewport: { value: 'mobile' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '768px 모바일 해상도에서 타이틀이 렌더링되는 모습.',
       },
     },
   },

--- a/src/widgets/award/ui/Title.stories.tsx
+++ b/src/widgets/award/ui/Title.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { AwardTitle } from './Title';
+
+const meta = {
+  title: 'Widgets/Award/Title',
+  component: AwardTitle,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Award 섹션 상단의 타이틀 컴포넌트. 영문 서브타이틀 "Award"와 한글 제목 "수상 기록"을 hgroup으로 묶어 표시합니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof AwardTitle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '기본',
+  parameters: {
+    docs: {
+      description: {
+        story: 'props 없이 정적으로 렌더링되는 타이틀.',
+      },
+    },
+  },
+};

--- a/src/widgets/award/ui/Viewport.stories.tsx
+++ b/src/widgets/award/ui/Viewport.stories.tsx
@@ -1,0 +1,82 @@
+import { AWARD_LIST } from '@entities/award';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { Viewport } from './Viewport';
+
+const meta = {
+  title: 'Widgets/Award/Viewport',
+  component: Viewport,
+  args: {
+    filteredList: AWARD_LIST,
+    safePage: 0,
+    onCardClick: fn(),
+    setCurrentPage: fn(),
+  },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          '수상 카드를 페이지 단위로 슬라이드하는 뷰포트 컴포넌트. itemsPerPage에 따라 2×2 / 3×2 / 5×2 그리드로 전환됩니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof Viewport>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Desktop: Story = {
+  name: 'Desktop (5×2, 10개/페이지)',
+  globals: {
+    viewport: { value: 'desktop' },
+  },
+  args: {
+    itemsPerPage: 10,
+    totalPages: Math.ceil(AWARD_LIST.length / 10),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '1920px 데스크탑 — 10개 카드가 한 페이지에 5×2로 표시됩니다.',
+      },
+    },
+  },
+};
+
+export const Tablet: Story = {
+  name: 'Tablet (3×2, 6개/페이지)',
+  globals: {
+    viewport: { value: 'tablet' },
+  },
+  args: {
+    itemsPerPage: 6,
+    totalPages: Math.ceil(AWARD_LIST.length / 6),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '768px 태블릿 — 6개 카드가 한 페이지에 3×2로 표시됩니다.',
+      },
+    },
+  },
+};
+
+export const Mobile: Story = {
+  name: 'Mobile (2×2, 4개/페이지)',
+  globals: {
+    viewport: { value: 'mobile' },
+  },
+  args: {
+    itemsPerPage: 4,
+    totalPages: Math.ceil(AWARD_LIST.length / 4),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '375px 모바일 — 4개 카드가 한 페이지에 2×2로 표시됩니다.',
+      },
+    },
+  },
+};

--- a/src/widgets/award/ui/Viewport.stories.tsx
+++ b/src/widgets/award/ui/Viewport.stories.tsx
@@ -27,11 +27,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Desktop: Story = {
-  name: 'Desktop (5×2, 10개/페이지)',
-  globals: {
-    viewport: { value: 'desktop' },
-  },
+export const Default: Story = {
+  name: '(5×2, 10개/페이지)',
   args: {
     itemsPerPage: 10,
     totalPages: Math.ceil(AWARD_LIST.length / 10),
@@ -39,43 +36,7 @@ export const Desktop: Story = {
   parameters: {
     docs: {
       description: {
-        story: '1920px 데스크탑 — 10개 카드가 한 페이지에 5×2로 표시됩니다.',
-      },
-    },
-  },
-};
-
-export const Tablet: Story = {
-  name: 'Tablet (3×2, 6개/페이지)',
-  globals: {
-    viewport: { value: 'tablet' },
-  },
-  args: {
-    itemsPerPage: 6,
-    totalPages: Math.ceil(AWARD_LIST.length / 6),
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: '768px 태블릿 — 6개 카드가 한 페이지에 3×2로 표시됩니다.',
-      },
-    },
-  },
-};
-
-export const Mobile: Story = {
-  name: 'Mobile (2×2, 4개/페이지)',
-  globals: {
-    viewport: { value: 'mobile' },
-  },
-  args: {
-    itemsPerPage: 4,
-    totalPages: Math.ceil(AWARD_LIST.length / 4),
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: '375px 모바일 — 4개 카드가 한 페이지에 2×2로 표시됩니다.',
+        story: '10개 카드가 한 페이지에 5×2로 표시됩니다.',
       },
     },
   },

--- a/src/widgets/award/ui/Viewport.stories.tsx
+++ b/src/widgets/award/ui/Viewport.stories.tsx
@@ -33,6 +33,9 @@ export const Default: Story = {
     itemsPerPage: 10,
     totalPages: Math.ceil(AWARD_LIST.length / 10),
   },
+  globals: {
+    viewport: { value: 'desktop' },
+  },
   parameters: {
     docs: {
       description: {
@@ -40,4 +43,20 @@ export const Default: Story = {
       },
     },
   },
+};
+
+export const Tablet = {
+  name: '(3×2, 6개/페이지)',
+  globals: {
+    viewport: { value: 'tablet' },
+  },
+  args: { itemsPerPage: 6, totalPages: Math.ceil(AWARD_LIST.length / 6) },
+};
+
+export const Mobile = {
+  name: '(2×2, 4개/페이지)',
+  globals: {
+    viewport: { value: 'mobile' },
+  },
+  args: { itemsPerPage: 4, totalPages: Math.ceil(AWARD_LIST.length / 4) },
 };

--- a/src/widgets/footer/ui/Footer.stories.tsx
+++ b/src/widgets/footer/ui/Footer.stories.tsx
@@ -28,44 +28,12 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Desktop: Story = {
-  name: 'Desktop (1920px)',
-  globals: {
-    viewport: { value: 'desktop' },
-  },
+export const Default: Story = {
+  name: '기본',
   parameters: {
     docs: {
       description: {
-        story: '1920px 데스크탑 해상도에서의 Footer 레이아웃.',
-      },
-    },
-  },
-};
-
-export const Tablet: Story = {
-  name: 'Tablet (768px)',
-  globals: {
-    viewport: { value: 'tablet' },
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: '768px 태블릿 해상도에서의 Footer 레이아웃.',
-      },
-    },
-  },
-};
-
-export const Mobile: Story = {
-  name: 'Mobile (375px)',
-  globals: {
-    viewport: { value: 'mobile' },
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          '375px 모바일 해상도에서의 Footer 레이아웃. footer__content가 column 방향으로 전환되고 footer__right가 좌측 정렬됩니다.',
+        story: 'Footer 레이아웃.',
       },
     },
   },

--- a/src/widgets/footer/ui/Footer.stories.tsx
+++ b/src/widgets/footer/ui/Footer.stories.tsx
@@ -2,7 +2,7 @@ import { MemoryRouter } from 'react-router-dom';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { Footer } from './ui/Footer';
+import { Footer } from './Footer';
 
 const meta = {
   title: 'Widgets/Footer',


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- #48 

### 뷰포트별 스토리 필요성?
- 어짜피 Storybook에 viewport 선택하는 곳이 있어서 구지 스토리별로 뷰포트를 만들경우 스토리가 상당히 많아지는 문제를 발견했습니다.
- 뷰포트 크기에 따른 것이 아닌 상태에 따라 스토리를 나눌 수 있도록 구현했습니다.
- UI 파일 1개 = 스토리 파일 1개를 유지할 수 있도록 Footer.stories.tsx의 위치를 변경했습니다.

### 핵심 변화

#### 변경 전
- 뷰포트별 스토리 존재
- auto docs 미존재

#### 변경 후
- 상태별 스토리 존재
- auto docs 존재

# 📋 작업 내용

- award 스토리 작성
- Footer 스토리 위치 변경
- viewport 오류 값 수정

# 📷 스크린 샷 (선택 사항)

<img width="1906" height="906" alt="image" src="https://github.com/user-attachments/assets/48bb99fb-8be3-49d7-ae40-96fae01b7fca" />
