### PR TITLE
👹 fix: iOS WebKit backface-visibility 투명화 버그 해결 (CoverFlip)

### DIFF
--- a/src/pages/privacy-policy/styles/PrivacyPolicy.css
+++ b/src/pages/privacy-policy/styles/PrivacyPolicy.css
@@ -371,6 +371,7 @@
 .privacy-policy__back-btn:hover {
   background-color: #5a4231;
   transform: translateY(-0.052vmax);
+  -webkit-transform: translateY(-0.052vmax);
 }
 
 .privacy-policy__back-btn svg {

--- a/src/shared/ui/ImageSlider/styles/ImageSlider.css
+++ b/src/shared/ui/ImageSlider/styles/ImageSlider.css
@@ -43,6 +43,7 @@
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -79,6 +80,7 @@
   bottom: 0.8vmax;
   left: 50%;
   transform: translateX(-50%);
+  -webkit-transform: translateX(-50%);
   background: rgba(0, 0, 0, 0.5);
   color: #fff;
   padding: 0.26vmax 0.78vmax;

--- a/src/shared/ui/Popup/styles/Popup.css
+++ b/src/shared/ui/Popup/styles/Popup.css
@@ -36,10 +36,12 @@
   from {
     opacity: 0;
     transform: scale(0.95);
+    -webkit-transform: scale(0.95);
   }
   to {
     opacity: 1;
     transform: scale(1);
+    -webkit-transform: scale(1);
   }
 }
 

--- a/src/widgets/award/styles/Card.css
+++ b/src/widgets/award/styles/Card.css
@@ -22,6 +22,7 @@
 
 .award__card:hover {
   transform: translateY(-0.3vmax);
+  -webkit-transform: translateY(-0.3vmax);
   box-shadow: 0 0.6vmax 1.2vmax rgba(0, 0, 0, 0.25);
 }
 

--- a/src/widgets/header/styles/Header.css
+++ b/src/widgets/header/styles/Header.css
@@ -32,6 +32,7 @@
 
 .header--hidden {
   transform: translateY(-100%);
+  -webkit-transform: translateY(-100%);
 }
 
 .header__logo {

--- a/src/widgets/hero/styles/Hero.css
+++ b/src/widgets/hero/styles/Hero.css
@@ -19,6 +19,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -63,10 +64,12 @@
   from {
     opacity: 0;
     transform: translate(-50%, -40%);
+    -webkit-transform: translate(-50%, -40%);
   }
   to {
     opacity: 1;
     transform: translate(-50%, -50%);
+    -webkit-transform: translate(-50%, -50%);
   }
 }
 
@@ -83,15 +86,18 @@
   0%,
   100% {
     transform: translateX(-50%) translateY(0);
+    -webkit-transform: translateX(-50%) translateY(0);
   }
   50% {
     transform: translateX(-50%) translateY(10px);
+    -webkit-transform: translateX(-50%) translateY(10px);
   }
 }
 
 .hero__down-icon {
   position: absolute;
   transform: translateX(-50%);
+  -webkit-transform: translateX(-50%);
   bottom: 2.5%;
   left: 50%;
   animation: bounce-down 2s ease-in-out infinite;
@@ -109,6 +115,7 @@
     width: 100%;
     height: 100%;
     transform: none;
+    -webkit-transform: none;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -129,6 +136,7 @@
   .hero__logo {
     position: static;
     transform: none;
+    -webkit-transform: none;
     order: 2;
     height: 37.5vmin;
     width: auto;
@@ -138,6 +146,7 @@
   .hero__company-text {
     position: static;
     transform: none;
+    -webkit-transform: none;
     order: 1;
     align-items: center;
     gap: 1.82vmin;
@@ -162,6 +171,7 @@
     bottom: 9.11vmin;
     left: 50%;
     transform: translateX(-50%);
+    -webkit-transform: translateX(-50%);
     font-size: 4.56vmin;
   }
 

--- a/src/widgets/history/styles/book/BackCover.css
+++ b/src/widgets/history/styles/book/BackCover.css
@@ -26,6 +26,7 @@
 
 .history__back-cover--centered {
   transform: translateX(50%);
+  -webkit-transform: translateX(50%);
 }
 
 .history__back-cover-spine {
@@ -76,6 +77,7 @@
 
   .history__back-cover--centered {
     transform: translateY(50%);
+    -webkit-transform: translateY(50%);
   }
 
   .history__back-cover-spine {
@@ -103,6 +105,7 @@
 
   .history__back-cover--centered {
     transform: translateY(50%);
+    -webkit-transform: translateY(50%);
   }
 
   .history__back-cover-spine {

--- a/src/widgets/history/styles/book/BookPageSide.css
+++ b/src/widgets/history/styles/book/BookPageSide.css
@@ -2,6 +2,7 @@
   position: absolute;
   inset: 0;
   perspective: 120vmax;
+  -webkit-perspective: 120vmax;
   z-index: 10;
 }
 
@@ -83,6 +84,7 @@
 @media (max-width: 1024px) {
   .history__book-page-flip-wrapper {
     perspective: 300vmin;
+    -webkit-perspective: 300vmin;
   }
 
   .history__book-page-left {
@@ -147,6 +149,7 @@
 @media (max-width: 767px) {
   .history__book-page-flip-wrapper {
     perspective: 614.4vmin;
+    -webkit-perspective: 614.4vmin;
   }
 
   .history__book-page-left {

--- a/src/widgets/history/styles/book/CoverFlip.css
+++ b/src/widgets/history/styles/book/CoverFlip.css
@@ -10,6 +10,7 @@
   width: 100%;
   height: 100%;
   transform-style: preserve-3d;
+  -webkit-transform-style: preserve-3d;
 }
 
 .history__book-cover-flip-panel--hidden {
@@ -28,6 +29,7 @@
 
 .history__book-cover-flip-panel--animating {
   transition: transform 0.8s ease-in-out;
+  will-change: transform;
 }
 
 .history__book-cover-flip-panel--forward.flipping {
@@ -44,30 +46,42 @@
   inset: 0;
   backface-visibility: hidden;
   -webkit-backface-visibility: hidden;
+}
 
+.history__book-cover-flip-front {
+  transform: translateZ(0.01px);
+  -webkit-transform: translateZ(0.01px);
+}
+
+.history__book-cover-flip-front-inner,
+.history__book-cover-flip-back-inner {
+  position: absolute;
+  inset: 0;
   overflow: hidden;
 }
 
 .history__book-cover-flip-back {
-  transform: rotateY(180deg);
+  transform: rotateY(180deg) translateZ(0.01px);
+  -webkit-transform: rotateY(180deg) translateZ(0.01px);
 }
 
-.history__book-cover-flip-panel--forward .history__book-cover-flip-front {
+.history__book-cover-flip-panel--forward .history__book-cover-flip-front-inner {
   border-top-right-radius: 0.78vmax;
   border-bottom-right-radius: 0.78vmax;
 }
 
-.history__book-cover-flip-panel--forward .history__book-cover-flip-back {
+.history__book-cover-flip-panel--forward .history__book-cover-flip-back-inner {
   border-top-left-radius: 0.78vmax;
   border-bottom-left-radius: 0.78vmax;
 }
 
-.history__book-cover-flip-panel--backward .history__book-cover-flip-front {
+.history__book-cover-flip-panel--backward
+  .history__book-cover-flip-front-inner {
   border-top-left-radius: 0.78vmax;
   border-bottom-left-radius: 0.78vmax;
 }
 
-.history__book-cover-flip-panel--backward .history__book-cover-flip-back {
+.history__book-cover-flip-panel--backward .history__book-cover-flip-back-inner {
   border-top-right-radius: 0.78vmax;
   border-bottom-right-radius: 0.78vmax;
 }
@@ -98,22 +112,27 @@
   }
 
   .history__book-cover-flip-back {
-    transform: rotateX(-180deg);
+    transform: rotateX(-180deg) translateZ(0.01px);
+    -webkit-transform: rotateX(-180deg) translateZ(0.01px);
   }
 
-  .history__book-cover-flip-panel--forward .history__book-cover-flip-front {
+  .history__book-cover-flip-panel--forward
+    .history__book-cover-flip-front-inner {
     border-radius: 0 0 1.953vmin 1.953vmin;
   }
 
-  .history__book-cover-flip-panel--forward .history__book-cover-flip-back {
+  .history__book-cover-flip-panel--forward
+    .history__book-cover-flip-back-inner {
     border-radius: 1.953vmin 1.953vmin 0 0;
   }
 
-  .history__book-cover-flip-panel--backward .history__book-cover-flip-front {
+  .history__book-cover-flip-panel--backward
+    .history__book-cover-flip-front-inner {
     border-radius: 1.953vmin 1.953vmin 0 0;
   }
 
-  .history__book-cover-flip-panel--backward .history__book-cover-flip-back {
+  .history__book-cover-flip-panel--backward
+    .history__book-cover-flip-back-inner {
     border-radius: 0 0 1.953vmin 1.953vmin;
   }
 }
@@ -123,19 +142,23 @@
     perspective: 614.4vmin;
   }
 
-  .history__book-cover-flip-panel--forward .history__book-cover-flip-front {
+  .history__book-cover-flip-panel--forward
+    .history__book-cover-flip-front-inner {
     border-radius: 0 0 4vmin 4vmin;
   }
 
-  .history__book-cover-flip-panel--forward .history__book-cover-flip-back {
+  .history__book-cover-flip-panel--forward
+    .history__book-cover-flip-back-inner {
     border-radius: 4vmin 4vmin 0 0;
   }
 
-  .history__book-cover-flip-panel--backward .history__book-cover-flip-front {
+  .history__book-cover-flip-panel--backward
+    .history__book-cover-flip-front-inner {
     border-radius: 4vmin 4vmin 0 0;
   }
 
-  .history__book-cover-flip-panel--backward .history__book-cover-flip-back {
+  .history__book-cover-flip-panel--backward
+    .history__book-cover-flip-back-inner {
     border-radius: 0 0 4vmin 4vmin;
   }
 }

--- a/src/widgets/history/styles/book/CoverFlip.css
+++ b/src/widgets/history/styles/book/CoverFlip.css
@@ -3,6 +3,7 @@
   inset: 0;
   z-index: 15;
   perspective: 120vmax;
+  -webkit-perspective: 120vmax;
 }
 
 .history__book-cover-flip-panel {
@@ -20,11 +21,13 @@
 .history__book-cover-flip-panel--forward {
   left: 0%;
   transform-origin: left center;
+  -webkit-transform-origin: left center;
 }
 
 .history__book-cover-flip-panel--backward {
   right: 0%;
   transform-origin: right center;
+  -webkit-transform-origin: right center;
 }
 
 .history__book-cover-flip-panel--animating {
@@ -34,10 +37,12 @@
 
 .history__book-cover-flip-panel--forward.flipping {
   transform: rotateY(-180deg);
+  -webkit-transform: rotateY(-180deg);
 }
 
 .history__book-cover-flip-panel--backward.flipping {
   transform: rotateY(180deg);
+  -webkit-transform: rotateY(180deg);
 }
 
 .history__book-cover-flip-front,
@@ -89,26 +94,31 @@
 @media (max-width: 1024px) {
   .history__book-cover-flip {
     perspective: 300vmin;
+    -webkit-perspective: 300vmin;
   }
 
   .history__book-cover-flip-panel--forward {
     left: 0;
     top: 0%;
     transform-origin: top;
+    -webkit-transform-origin: top;
   }
 
   .history__book-cover-flip-panel--backward {
     right: 0;
     bottom: 0%;
     transform-origin: bottom;
+    -webkit-transform-origin: bottom;
   }
 
   .history__book-cover-flip-panel--forward.flipping {
     transform: rotateX(180deg);
+    -webkit-transform: rotateX(180deg);
   }
 
   .history__book-cover-flip-panel--backward.flipping {
     transform: rotateX(-180deg);
+    -webkit-transform: rotateX(-180deg);
   }
 
   .history__book-cover-flip-back {
@@ -140,6 +150,7 @@
 @media (max-width: 767px) {
   .history__book-cover-flip {
     perspective: 614.4vmin;
+    -webkit-perspective: 614.4vmin;
   }
 
   .history__book-cover-flip-panel--forward

--- a/src/widgets/history/styles/book/FrontCover.css
+++ b/src/widgets/history/styles/book/FrontCover.css
@@ -26,6 +26,7 @@
 
 .history__front-cover--centered {
   transform: translateX(-50%);
+  -webkit-transform: translateX(-50%);
 }
 
 .history__front-cover-spine {
@@ -90,6 +91,7 @@
   font-weight: 700;
 
   transform: skewX(-10deg);
+  -webkit-transform: skewX(-10deg);
 }
 
 .history__front-cover-year-number {
@@ -115,6 +117,7 @@
 
   .history__front-cover--centered {
     transform: translateY(-50%);
+    -webkit-transform: translateY(-50%);
   }
 
   .history__front-cover-spine {

--- a/src/widgets/history/styles/book/PageFlip.css
+++ b/src/widgets/history/styles/book/PageFlip.css
@@ -6,6 +6,7 @@
   left: 0;
 
   transform-style: preserve-3d;
+  -webkit-transform-style: preserve-3d;
   z-index: 10;
 }
 
@@ -17,6 +18,7 @@
   right: 0;
 
   transform-style: preserve-3d;
+  -webkit-transform-style: preserve-3d;
   z-index: 10;
 }
 
@@ -28,24 +30,29 @@
   left: 0;
   right: 0;
   transform-origin: left center;
+  -webkit-transform-origin: left center;
 }
 
 .history__book-page-flip-panel--backward {
   left: 0;
   right: 0;
   transform-origin: right center;
+  -webkit-transform-origin: right center;
 }
 
 .history__book-page-flip-panel--animating {
   transition: transform 0.8s ease-in-out;
+  will-change: transform;
 }
 
 .history__book-page-flip-panel--forward.flipping {
   transform: rotateY(-180deg);
+  -webkit-transform: rotateY(-180deg);
 }
 
 .history__book-page-flip-panel--backward.flipping {
   transform: rotateY(180deg);
+  -webkit-transform: rotateY(180deg);
 }
 
 .history__book-page-flip-front,
@@ -59,6 +66,7 @@
 
 .history__book-page-flip-back {
   transform: rotateY(180deg);
+  -webkit-transform: rotateY(180deg);
 }
 
 @media (max-width: 1024px) {
@@ -78,22 +86,27 @@
 
   .history__book-page-flip-panel--forward {
     transform-origin: top;
+    -webkit-transform-origin: top;
   }
 
   .history__book-page-flip-panel--backward {
     transform-origin: bottom;
+    -webkit-transform-origin: bottom;
   }
 
   .history__book-page-flip-panel--forward.flipping {
     transform: rotateX(180deg);
+    -webkit-transform: rotateX(180deg);
   }
 
   .history__book-page-flip-panel--backward.flipping {
     transform: rotateX(-180deg);
+    -webkit-transform: rotateX(-180deg);
   }
 
   .history__book-page-flip-back {
     transform: rotateX(-180deg);
+    -webkit-transform: rotateX(-180deg);
   }
 }
 

--- a/src/widgets/history/styles/book/content_container/Content.css
+++ b/src/widgets/history/styles/book/content_container/Content.css
@@ -124,6 +124,7 @@
 
 .content__image--has-image:hover img {
   transform: scale(1.07);
+  -webkit-transform: scale(1.07);
 }
 
 .content__image-zoom {

--- a/src/widgets/history/ui/book/CoverFlip.tsx
+++ b/src/widgets/history/ui/book/CoverFlip.tsx
@@ -57,8 +57,16 @@ export function BookCoverFlip({
         ref={flipPanelRef}
         className={`history__book-cover-flip-panel history__book-cover-flip-panel--${flipDirection} history__book-cover-flip-panel--hidden`}
       >
-        <div className='history__book-cover-flip-front'>{frontContent}</div>
-        <div className='history__book-cover-flip-back'>{backContent}</div>
+        <div className='history__book-cover-flip-front'>
+          <div className='history__book-cover-flip-front-inner'>
+            {frontContent}
+          </div>
+        </div>
+        <div className='history__book-cover-flip-back'>
+          <div className='history__book-cover-flip-back-inner'>
+            {backContent}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/widgets/map/styles/MapCard.css
+++ b/src/widgets/map/styles/MapCard.css
@@ -105,6 +105,7 @@
   background-color: var(--brown-900);
   box-shadow: none;
   transform: translateY(1px);
+  -webkit-transform: translateY(1px);
 }
 
 .map__description_call svg {

--- a/src/widgets/patent/styles/Card.css
+++ b/src/widgets/patent/styles/Card.css
@@ -15,6 +15,7 @@
 
 .patent__card:hover {
   transform: translateY(-0.25vmax);
+  -webkit-transform: translateY(-0.25vmax);
   box-shadow: 0 0.8vmax 1.6vmax rgba(0, 0, 0, 0.2);
 }
 

--- a/src/widgets/patent/styles/PatentTitle.css
+++ b/src/widgets/patent/styles/PatentTitle.css
@@ -11,6 +11,7 @@
 .patent__title h2:last-of-type {
   color: #c9a96e;
   transform: skewX(-8deg);
+  -webkit-transform: skewX(-8deg);
   display: inline-block;
   line-height: 1;
 }

--- a/src/widgets/vision/styles/Title.css
+++ b/src/widgets/vision/styles/Title.css
@@ -1,6 +1,7 @@
 .vision__title {
   opacity: 0;
   transform: translateY(2.5vmax);
+  -webkit-transform: translateY(2.5vmax);
   transition:
     opacity 0.7s ease,
     transform 0.7s ease;
@@ -9,6 +10,7 @@
 .vision__title.is-visible {
   opacity: 1;
   transform: translateY(0);
+  -webkit-transform: translateY(0);
 }
 
 .vision__title h2 {
@@ -20,6 +22,7 @@
 .vision__title h2:last-of-type {
   color: #c9a96e;
   transform: skewX(-8deg);
+  -webkit-transform: skewX(-8deg);
   display: inline-block;
   line-height: 1;
 }

--- a/src/widgets/vision/styles/VisionItem.css
+++ b/src/widgets/vision/styles/VisionItem.css
@@ -3,6 +3,7 @@
 
   opacity: 0;
   transform: translateY(2.5vmax);
+  -webkit-transform: translateY(2.5vmax);
   transition:
     opacity 0.7s ease,
     transform 0.7s ease;
@@ -11,6 +12,7 @@
 .vision__content.is-visible {
   opacity: 1;
   transform: translateY(0);
+  -webkit-transform: translateY(0);
 }
 
 .vision__content {
@@ -55,6 +57,7 @@
 
 .vision__content:hover .vision__content__image img {
   transform: scale(1.08);
+  -webkit-transform: scale(1.08);
 }
 
 .vision__content_text {
@@ -97,6 +100,7 @@
   font-size: 3.13vmax;
   color: var(--color-main-h3);
   transform: skewX(-10deg);
+  -webkit-transform: skewX(-10deg);
 }
 
 .vision__content__title__main h4 {


### PR DESCRIPTION
<!--
```
- PR이 승인되면 해당 브랜치 삭제하기
```
-->

# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- #105

### iOS WebKit의 `backface-visibility` + `overflow` 충돌 버그

**문제 원인**

iOS Safari(WebKit 엔진)는 3D 플립 애니메이션에서 표준 Chrome/Firefox와 다른 GPU 합성(compositing) 전략을 사용합니다.

기존 코드는 `history__book-cover-flip-front`와 `history__book-cover-flip-back` 요소에 **`backface-visibility: hidden`과 `overflow: hidden`을 동시에 적용**하고 있었습니다.

WebKit은 `backface-visibility: hidden`이 적용된 요소가 동시에 `overflow: hidden`(혹은 `border-radius`)을 가질 경우, **별도의 GPU 레이어를 생성하지 못하거나 잘못된 레이어 순서**로 합성합니다. 그 결과, `closing-front`와 `closing-back` 상태(즉, 애니메이션이 끝나는 시점)에서 해당 요소의 **outer 면이 투명하게 렌더링**되는 현상이 발생했습니다.

이는 iOS WebKit의 오래된 known issue로, 다음 두 속성의 충돌에서 기인합니다:
- `backface-visibility: hidden` → GPU 레이어 분리를 요구
- `overflow: hidden` + `border-radius` → 동일 GPU 레이어에서 클리핑을 요구

두 요구사항이 동일한 요소에 존재하면 WebKit이 레이어 처리를 포기하고 면을 투명하게 처리합니다.

### 핵심 변화

#### 변경 전

`front` / `back` 요소 하나에 `backface-visibility`, `overflow: hidden`, `border-radius`를 모두 적용:

```html
<div class="history__book-cover-flip-front">  <!-- backface-visibility + overflow + border-radius 혼재 -->
  {frontContent}
</div>
```

#### 변경 후

역할을 **두 레이어로 분리**:

- **외부 요소** (`-front`, `-back`): `backface-visibility: hidden` + `translateZ(0.01px)`만 담당 → WebKit이 독립적인 GPU 레이어로 인식
- **내부 요소** (`-front-inner`, `-back-inner`): `overflow: hidden` + `border-radius`만 담당 → 별개의 클리핑 컨텍스트

```html
<div class="history__book-cover-flip-front">        <!-- backface-visibility + translateZ(0.01px) -->
  <div class="history__book-cover-flip-front-inner"> <!-- overflow + border-radius -->
    {frontContent}
  </div>
</div>
```

추가적으로 WebKit GPU 레이어 생성을 강제하기 위해 아래 CSS도 적용했습니다:

| 속성 | 이유 |
|------|------|
| `-webkit-transform-style: preserve-3d` | WebKit 벤더 프리픽스 누락 보완 |
| `translateZ(0.01px)` on front/back | WebKit이 각 면을 별도 GPU 레이어로 강제 승격 |
| `will-change: transform` on animating panel | 애니메이션 시작 전 GPU 레이어 사전 할당 |
| `-webkit-transform` 프리픽스 | 구형 iOS Safari 호환성 보장 |

# 📋 작업 내용

- `CoverFlip.css`: `front` / `back` 면에서 `overflow: hidden` 제거 후 내부 wrapper(`-inner`)로 분리
- `CoverFlip.css`: 모든 `transform`에 `-webkit-transform` 벤더 프리픽스 추가
- `CoverFlip.css`: `translateZ(0.01px)`로 WebKit GPU 레이어 강제 승격
- `CoverFlip.css`: 애니메이션 패널에 `will-change: transform` 추가
- `CoverFlip.tsx`: `front` / `back` div 내부에 `-inner` wrapper 요소 추가
- `CoverFlip.css`: 반응형 미디어쿼리의 `border-radius`를 모두 `-inner` 클래스로 이동

# 📷 스크린 샷 (선택 사항)
- 변경 전
<img width="1080" height="2640" alt="KakaoTalk_20260419_215330588" src="https://github.com/user-attachments/assets/29f41891-b76a-45f9-97df-c04452940af7" />

- 변경 후
정상적으로 커버 플립핑