### PR TITLE
⚙️ chore: dependabot CI 제한

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   chromatic:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lighthouse-comment.yml
+++ b/.github/workflows/lighthouse-comment.yml
@@ -9,7 +9,7 @@ jobs:
   comment:
     name: Post Lighthouse Comment
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request'
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.actor.login != 'dependabot[bot]'
     permissions:
       pull-requests: write
       issues: write

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   lighthouse:
+    if: github.actor != 'dependabot[bot]'
     name: Lighthouse
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

관련 이슈 없음

### CI 봇 PR 실행 제한

- Dependabot이 생성한 PR에서는 Chromatic, Lighthouse CI, Lighthouse Comment 워크플로우가 불필요하게 실행됨
- `github.actor != 'dependabot[bot]'` 조건을 추가하여 봇 PR에서 해당 워크플로우가 동작하지 않도록 제한

### 핵심 변화

#### 변경 전

- Dependabot PR 포함 모든 PR에서 Chromatic / Lighthouse 워크플로우 실행

#### 변경 후

- `dependabot[bot]` 액터의 PR에서 세 워크플로우(`chromatic.yml`, `lighthouse.yml`, `lighthouse-comment.yml`) 실행 스킵

# 📋 작업 내용

- `.github/workflows/chromatic.yml`: `if: github.actor != 'dependabot[bot]'` 조건 추가
- `.github/workflows/lighthouse.yml`: `if: github.actor != 'dependabot[bot]'` 조건 추가
- `.github/workflows/lighthouse-comment.yml`: `if` 조건에 `github.event.workflow_run.actor.login != 'dependabot[bot]'` 추가