### PR TITLE
⚙️ chore: prod 빌드 명령 교체

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docker:dev:run": "docker run -it --name induel-fe-dev -p 5173:5173 -v .:/home/induel -v /home/induel/node_modules induel-fe-dev",
     "docker:dev": "vite --config vite.config.docker.ts",
     "docker": "npm run docker:dev:build && npm run docker:dev:run",
-    "build": "npm run build:staging",
+    "build": "npm run build:prod",
     "build:staging": "tsc -b && vite build --mode staging",
     "build:prod": "tsc -b && vite build --mode production",
     "lint": "eslint .",


### PR DESCRIPTION
# 💫 테스크

> [!WARNING]  
> 본 PR 병합 후 develop -> main으로의 병합 PR이 작성되어야 실제 배포로 이어집니다.

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- #116

### 소주제1 — build 스크립트 명시적 분리

`npm run build`가 내부적으로 `tsc -b && vite build`를 직접 실행하고 있었는데, `--mode` 플래그 없이 빌드하면 Vite가 `.env.production`을 로드하지 않을 수 있어 프로덕션 환경 변수 보장이 불명확했습니다.

`build:prod` 스크립트로 위임함으로써 기본 `build` 명령이 항상 `--mode production`으로 실행되도록 명시화했습니다.

### 핵심 변화

#### 변경 전

```json
"build": "tsc -b && vite build"
```

#### 변경 후

```json
"build": "npm run build:prod",
"build:prod": "tsc -b && vite build --mode production"
```

`npm run build` 실행 시 항상 `--mode production`이 적용되어 Vite가 `.env.production`을 명시적으로 로드함.

# 📋 작업 내용

- `package.json`: `build` 스크립트를 `build:prod`로 위임, `build:prod`에 `--mode production` 명시

# 📷 스크린 샷 (선택 사항)

동작 화면 첨부