### PR TITLE
👹 fix: mobile 주소창 동작 시 레이아웃 꿀렁거림 및 map 마커/info card 수정

### DIFF
--- a/src/shared/ui/Popup/styles/Popup.css
+++ b/src/shared/ui/Popup/styles/Popup.css
@@ -88,7 +88,7 @@
 @media (max-width: 1024px) {
   .popup {
     width: 64.584vw;
-    height: 79.6dvh;
+    height: 79.6svh;
     padding: 1.95vw;
     border-radius: 1.303vw;
     gap: 1.303vw;
@@ -114,7 +114,7 @@
 @media (max-width: 767px) {
   .popup {
     width: clamp(321px, 91.73vw, 459px);
-    height: 74.7dvh;
+    height: 74.7svh;
     padding: clamp(14px, 4vw, 20px);
     border-radius: clamp(9px, 2.666vw, 13px);
     gap: clamp(14px, 4vw, 20px);

--- a/src/widgets/hero/styles/Hero.css
+++ b/src/widgets/hero/styles/Hero.css
@@ -54,14 +54,17 @@
 
 .hero__company-name {
   font-size: max(60px, 6.25vw);
+  color: var(--white);
 }
 
 .hero__company-name-en {
   font-size: max(32px, 2.6vw);
+  color: var(--white);
 }
 
 .hero__established {
   font-size: max(28px, 2.08vw);
+  color: var(--white);
 }
 
 @keyframes fade-in {

--- a/src/widgets/hero/ui/Hero.tsx
+++ b/src/widgets/hero/ui/Hero.tsx
@@ -57,6 +57,7 @@ function Hero({ showScrollArrow }: { showScrollArrow: boolean }) {
               0 0 20px rgba(0, 0, 0, 1),
               0 0 60px rgba(0, 0, 0, 1)
             `,
+            color: 'white',
           }}
         >
           현재 개발중입니다!

--- a/src/widgets/map/model/mapMarker.ts
+++ b/src/widgets/map/model/mapMarker.ts
@@ -25,12 +25,36 @@ function createMarkerSvg() {
 `;
 }
 
-const MARKER_VMAX = 2.292;
+const MARKER_DESKTOP_VMAX = 2.292;
+const MARKER_TABLET_VMIN = 7;
+const MARKER_MOBILE_VMIN = 10;
 
 function getMarkerConfig() {
-  const vmax = Math.max(window.innerWidth, window.innerHeight) / 100;
-  const iconW = Math.round(MARKER_VMAX * vmax);
+  const width = window.innerWidth;
+
+  const maxPx = Math.max(window.innerWidth, window.innerHeight);
+  const minPx = Math.min(window.innerWidth, window.innerHeight);
+
+  const vmaxPx = maxPx / 100;
+  const vminPx = minPx / 100;
+
+  let size: number;
+  let unitPx: number;
+
+  if (width <= 767) {
+    size = MARKER_MOBILE_VMIN;
+    unitPx = vminPx;
+  } else if (width <= 1024) {
+    size = MARKER_TABLET_VMIN;
+    unitPx = vminPx;
+  } else {
+    size = MARKER_DESKTOP_VMAX;
+    unitPx = vmaxPx;
+  }
+
+  const iconW = Math.round(size * unitPx);
   const iconH = Math.round((iconW * 56) / 44);
+
   return {
     iconW,
     iconH,
@@ -38,7 +62,6 @@ function getMarkerConfig() {
     anchorY: Math.round((iconH * 54) / 56),
   };
 }
-
 function createMarkerIcon() {
   const { iconW, iconH, anchorX, anchorY } = getMarkerConfig();
   return {

--- a/src/widgets/map/styles/mapInfoCard.css
+++ b/src/widgets/map/styles/mapInfoCard.css
@@ -4,7 +4,7 @@
   overflow: hidden;
   box-shadow: 0 0.417vmax 1.25vmax rgba(0, 0, 0, 0.16);
   width: 15vmax;
-  height: 9vmax;
+  min-width: 240px;
 }
 
 .map__info__tail {
@@ -20,25 +20,23 @@
   background: var(--footer-background);
   padding: 0.65vmax 0.75vmax;
   display: flex;
-  flex-direction: row;
   align-items: center;
   gap: 0.55vmax;
 }
 
 .map__info__logo {
   width: 1.3vmax;
-  height: auto;
 }
 
 .map__info__name {
   color: white;
   font-weight: 700;
-  font-size: max(13px, 0.9vw);
+  font-size: clamp(13px, 0.9vw, 18px);
 }
 
 .map__info__subtitle {
   color: rgba(255, 255, 255, 0.5);
-  font-size: max(10px, 0.664vw);
+  font-size: clamp(10px, 0.664vw, 14px);
 }
 
 .map__info__body {
@@ -70,26 +68,123 @@
 
 .map__info__icon {
   width: 0.8vmax;
-  height: 0.8vmax;
 }
 
-.map__info__icon-path {
-  fill: #38271d;
-}
-
-.map__info__phone {
+.map__info__phone,
+.map__info__address-main {
+  font-size: clamp(12px, 0.81vw, 16px);
   color: #38271d;
-  font-size: max(12px, 0.81vw);
-  font-weight: 600;
   text-decoration: none;
 }
 
-.map__info__address-main {
-  color: #424242;
-  font-size: max(12px, 0.81vw);
+.map__info__address-sub {
+  font-size: clamp(10px, 0.664vw, 14px);
+  color: #666;
 }
 
-.map__info__address-sub {
-  color: #666666;
-  font-size: max(10px, 0.664vw);
+@media (max-width: 1024px) {
+  .map__info__card {
+    width: 28.65vmin;
+    border-radius: 0.8vmin;
+    box-shadow: 0 0.5vmin 1.2vmin rgba(0, 0, 0, 0.14);
+  }
+
+  .map__info__header {
+    padding: 1.2vmin 1.3vmin;
+    gap: 0.9vmin;
+  }
+
+  .map__info__logo {
+    width: 2.4vmin;
+  }
+
+  .map__info__body {
+    padding: 1.2vmin 1.3vmin;
+    gap: 0.9vmin;
+  }
+
+  .map__info__icon-box {
+    width: 2.4vmin;
+    height: 2.4vmin;
+  }
+
+  .map__info__icon {
+    width: 1.5vmin;
+  }
+
+  .map__info__name {
+    font-size: clamp(14px, 1.8vmin, 18px);
+  }
+
+  .map__info__subtitle {
+    font-size: clamp(11px, 1.3vmin, 14px);
+  }
+
+  .map__info__phone,
+  .map__info__address-main {
+    font-size: clamp(12px, 1.6vmin, 16px);
+  }
+
+  .map__info__address-sub {
+    font-size: clamp(10px, 1.3vmin, 14px);
+  }
+}
+
+@media (max-width: 767px) {
+  .map__info__card {
+    width: 69.5vmin;
+    border-radius: 2.6vmin;
+    box-shadow: 0 0.8vmin 3vmin rgba(0, 0, 0, 0.12);
+  }
+
+  .map__info__header {
+    padding: 3.2vmin 3.7vmin;
+    gap: 2.6vmin;
+  }
+
+  .map__info__logo {
+    width: 5.8vmin;
+  }
+
+  .map__info__body {
+    padding: 3.2vmin 3.7vmin;
+    gap: 2.6vmin;
+  }
+
+  .map__info__row {
+    gap: 2.6vmin;
+  }
+
+  .map__info__icon-box {
+    width: 5.8vmin;
+    height: 5.8vmin;
+    border-radius: 1.6vmin;
+  }
+
+  .map__info__icon {
+    width: 3vmin;
+  }
+
+  .map__info__name {
+    font-size: 4.2vmin;
+  }
+
+  .map__info__subtitle {
+    font-size: 3.2vmin;
+  }
+
+  .map__info__phone,
+  .map__info__address-main {
+    font-size: 3.5vmin;
+  }
+
+  .map__info__address-sub {
+    font-size: 3vmin;
+  }
+
+  .map__info__tail {
+    border-left: 1.6vmin solid transparent;
+    border-right: 1.6vmin solid transparent;
+    border-top: 1.6vmin solid white;
+  }
 }

--- a/src/widgets/map/styles/mapInfoCard.css
+++ b/src/widgets/map/styles/mapInfoCard.css
@@ -31,12 +31,12 @@
 .map__info__name {
   color: white;
   font-weight: 700;
-  font-size: clamp(13px, 0.9vw, 18px);
+  font-size: max(13px, 0.833vw);
 }
 
 .map__info__subtitle {
   color: rgba(255, 255, 255, 0.5);
-  font-size: clamp(10px, 0.664vw, 14px);
+  font-size: max(10px, 0.625vw);
 }
 
 .map__info__body {
@@ -72,13 +72,13 @@
 
 .map__info__phone,
 .map__info__address-main {
-  font-size: clamp(12px, 0.81vw, 16px);
+  font-size: max(12px, 0.729vw);
   color: #38271d;
   text-decoration: none;
 }
 
 .map__info__address-sub {
-  font-size: clamp(10px, 0.664vw, 14px);
+  font-size: max(10px, 0.625vw);
   color: #666;
 }
 

--- a/src/widgets/map/styles/mapMarker.css
+++ b/src/widgets/map/styles/mapMarker.css
@@ -18,3 +18,15 @@
 .map__marker__circle {
   fill: white;
 }
+
+@media (max-width: 1024px) {
+  .map__marker {
+    width: 7vmin;
+  }
+}
+
+@media (max-width: 767px) {
+  .map__marker {
+    width: 10vmin;
+  }
+}

--- a/src/widgets/patent/styles/Card.css
+++ b/src/widgets/patent/styles/Card.css
@@ -17,6 +17,6 @@
 @media (max-width: 767px) {
   .patent__card {
     width: 100%;
-    height: 35.1dvh;
+    height: 35.1svh;
   }
 }

--- a/src/widgets/vision/styles/VisionItem.css
+++ b/src/widgets/vision/styles/VisionItem.css
@@ -165,7 +165,7 @@
 @media (max-width: 767px) {
   .vision__content {
     flex-direction: column;
-    height: 62.5dvh;
+    height: 62.5svh;
   }
 
   .vision__content__image {


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- #105

### 모바일 주소창 표시/숨김 시 레이아웃 꿀렁거림

`vh`와 `dvh` 단위는 모바일 브라우저의 주소창 동작과 연동되어 레이아웃을 재계산(reflow)한다.

- `dvh` (Dynamic Viewport Height): 주소창 변화에 실시간 반응 → 직접적인 꿀렁거림 원인
- `vh`: 주소창 없는 상태 기준 → 주소창 등장 시 레이아웃 재계산 발생

`svh` (Small Viewport Height)로 교체하면 주소창이 항상 표시된 최소 뷰포트를 기준으로 고정되어 재계산이 발생하지 않는다.

### 핵심 변화

#### 변경 전

```css
/* 주소창 동작 시 레이아웃 재계산 발생 */
height: 100vh;
height: 62.5dvh;
height: 35.1dvh;
```

#### 변경 후

```css
/* 주소창 동작과 무관하게 레이아웃 고정 */
height: 100svh;
height: 62.5svh;
height: 35.1svh;
```

# 📋 작업 내용

- `widgets/hero/styles/Hero.css`: `100vh` → `100svh`
- `widgets/history/styles/History.css`: `100vh` → `100svh` (기본, 1024px, 767px 3곳)
- `widgets/map/styles/Map.css`: `100vh` → `100svh` (1024px, 767px)
- `widgets/map/styles/MapCard.css`: `vh` → `svh` (26.7, 22.22, 24.26)
- `widgets/patent/styles/Card.css`: `35.1dvh` → `35.1svh`
- `widgets/vision/styles/VisionItem.css`: `62.5dvh` → `62.5svh`
- `shared/ui/Popup/styles/Popup.css`: `dvh`/`vh` → `svh` (5곳)
- `widgets/map/ui/Map.tsx`: 지도 마커 크기 변경에 따른 위치 보정
- `widgets/map`: 마커 및 info card 4k, 8k 디자인 수정