### PR TITLE
✨ feat: 스크린 리더(ARIA) 전체 접근성 개선

### DIFF
--- a/src/app/styles/index.css
+++ b/src/app/styles/index.css
@@ -107,6 +107,25 @@
   border: 0;
 }
 
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 1rem;
+  z-index: 9999;
+  padding: 0.5rem 1rem;
+  background: var(--brown-400);
+  color: var(--white);
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 0 0 4px 4px;
+  text-decoration: none;
+  transition: top 0.1s;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
 p,
 span,
 h1,

--- a/src/features/award/ui/Pagination.test.tsx
+++ b/src/features/award/ui/Pagination.test.tsx
@@ -10,10 +10,10 @@ describe('Pagination', () => {
         <Pagination currentPage={0} totalPages={3} onPageChange={vi.fn()} />,
       );
       expect(
-        screen.getByRole('button', { name: 'Previous page' }),
+        screen.getByRole('button', { name: '이전 페이지' }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: 'Next page' }),
+        screen.getByRole('button', { name: '다음 페이지' }),
       ).toBeInTheDocument();
     });
 
@@ -22,13 +22,13 @@ describe('Pagination', () => {
         <Pagination currentPage={0} totalPages={3} onPageChange={vi.fn()} />,
       );
       expect(
-        screen.getByRole('button', { name: 'Go to page 1' }),
+        screen.getByRole('button', { name: '1페이지' }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: 'Go to page 2' }),
+        screen.getByRole('button', { name: '2페이지' }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: 'Go to page 3' }),
+        screen.getByRole('button', { name: '3페이지' }),
       ).toBeInTheDocument();
     });
 
@@ -45,9 +45,10 @@ describe('Pagination', () => {
       render(
         <Pagination currentPage={1} totalPages={3} onPageChange={vi.fn()} />,
       );
-      expect(
-        screen.getByRole('button', { name: 'Go to page 2' }),
-      ).toHaveAttribute('aria-current', 'page');
+      expect(screen.getByRole('button', { name: '2페이지' })).toHaveAttribute(
+        'aria-current',
+        'page',
+      );
     });
 
     it('비활성 dot에는 aria-current가 없다', () => {
@@ -55,7 +56,7 @@ describe('Pagination', () => {
         <Pagination currentPage={1} totalPages={3} onPageChange={vi.fn()} />,
       );
       expect(
-        screen.getByRole('button', { name: 'Go to page 1' }),
+        screen.getByRole('button', { name: '1페이지' }),
       ).not.toHaveAttribute('aria-current');
     });
 
@@ -63,7 +64,7 @@ describe('Pagination', () => {
       render(
         <Pagination currentPage={0} totalPages={3} onPageChange={vi.fn()} />,
       );
-      expect(screen.getByRole('button', { name: 'Go to page 1' })).toHaveClass(
+      expect(screen.getByRole('button', { name: '1페이지' })).toHaveClass(
         'award__pagination_dot--active',
       );
     });
@@ -72,9 +73,9 @@ describe('Pagination', () => {
       render(
         <Pagination currentPage={0} totalPages={3} onPageChange={vi.fn()} />,
       );
-      expect(
-        screen.getByRole('button', { name: 'Go to page 2' }),
-      ).not.toHaveClass('award__pagination_dot--active');
+      expect(screen.getByRole('button', { name: '2페이지' })).not.toHaveClass(
+        'award__pagination_dot--active',
+      );
     });
   });
 
@@ -89,7 +90,7 @@ describe('Pagination', () => {
         />,
       );
 
-      fireEvent.click(screen.getByRole('button', { name: 'Go to page 2' }));
+      fireEvent.click(screen.getByRole('button', { name: '2페이지' }));
 
       expect(onPageChange).toHaveBeenCalledWith(1);
     });
@@ -104,7 +105,7 @@ describe('Pagination', () => {
         />,
       );
 
-      fireEvent.click(screen.getByRole('button', { name: 'Previous page' }));
+      fireEvent.click(screen.getByRole('button', { name: '이전 페이지' }));
 
       // wrapPage(-1, 3) = 2
       expect(onPageChange).toHaveBeenCalledWith(2);
@@ -120,7 +121,7 @@ describe('Pagination', () => {
         />,
       );
 
-      fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+      fireEvent.click(screen.getByRole('button', { name: '다음 페이지' }));
 
       // wrapPage(3, 3) = 0
       expect(onPageChange).toHaveBeenCalledWith(0);

--- a/src/features/award/ui/Pagination.tsx
+++ b/src/features/award/ui/Pagination.tsx
@@ -17,20 +17,24 @@ export function Pagination({
       <button
         className='award__pagination_arrow'
         type='button'
-        aria-label='Previous page'
+        aria-label='이전 페이지'
         onClick={() => onPageChange(wrapPage(currentPage - 1, totalPages))}
       >
-        <IoIosArrowBack />
+        <IoIosArrowBack aria-hidden='true' />
       </button>
 
-      <div className='award__pagination_dots'>
+      <div
+        className='award__pagination_dots'
+        role='group'
+        aria-label='페이지 목록'
+      >
         {Array.from({ length: totalPages }, (_, pageIndex) => {
           const isActive = pageIndex === currentPage;
           return (
             <button
               key={pageIndex}
               type='button'
-              aria-label={`Go to page ${pageIndex + 1}`}
+              aria-label={`${pageIndex + 1}페이지`}
               aria-current={isActive ? 'page' : undefined}
               className={`award__pagination_dot ${isActive ? 'award__pagination_dot--active' : ''}`}
               onClick={() => onPageChange(pageIndex)}
@@ -39,17 +43,23 @@ export function Pagination({
         })}
       </div>
 
-      <span className='award__pagination_info'>
+      <span
+        className='award__pagination_info'
+        aria-live='polite'
+        aria-atomic='true'
+      >
+        <span className='sr-only'>현재 </span>
         {currentPage + 1}/{totalPages}
+        <span className='sr-only'> 페이지</span>
       </span>
 
       <button
         className='award__pagination_arrow'
         type='button'
-        aria-label='Next page'
+        aria-label='다음 페이지'
         onClick={() => onPageChange(wrapPage(currentPage + 1, totalPages))}
       >
-        <IoIosArrowForward />
+        <IoIosArrowForward aria-hidden='true' />
       </button>
     </div>
   );

--- a/src/features/award/ui/YearCategory.test.tsx
+++ b/src/features/award/ui/YearCategory.test.tsx
@@ -7,7 +7,7 @@ const yearList: (string | number)[] = ['전체', 2008, 2006, 2005];
 
 describe('YearCategory', () => {
   describe('렌더링', () => {
-    it('tablist 역할로 렌더링된다', () => {
+    it('navigation 역할로 렌더링된다', () => {
       render(
         <YearCategory
           yearList={yearList}
@@ -15,7 +15,9 @@ describe('YearCategory', () => {
           onYearChange={vi.fn()}
         />,
       );
-      expect(screen.getByRole('tablist')).toBeInTheDocument();
+      expect(
+        screen.getByRole('navigation', { name: '연도 필터' }),
+      ).toBeInTheDocument();
     });
 
     it('yearList 항목 수만큼 버튼이 렌더링된다', () => {
@@ -26,7 +28,7 @@ describe('YearCategory', () => {
           onYearChange={vi.fn()}
         />,
       );
-      expect(screen.getAllByRole('tab')).toHaveLength(yearList.length);
+      expect(screen.getAllByRole('button')).toHaveLength(yearList.length);
     });
 
     it('각 연도 텍스트가 렌더링된다', () => {
@@ -43,7 +45,7 @@ describe('YearCategory', () => {
   });
 
   describe('활성 상태', () => {
-    it('activeYear 버튼은 aria-selected=true이다', () => {
+    it('activeYear 버튼은 aria-current=true이다', () => {
       render(
         <YearCategory
           yearList={yearList}
@@ -51,10 +53,10 @@ describe('YearCategory', () => {
           onYearChange={vi.fn()}
         />,
       );
-      expect(screen.getByText('2008')).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByText('2008')).toHaveAttribute('aria-current', 'true');
     });
 
-    it('비활성 버튼은 aria-selected=false이다', () => {
+    it('비활성 버튼은 aria-current가 없다', () => {
       render(
         <YearCategory
           yearList={yearList}
@@ -62,10 +64,7 @@ describe('YearCategory', () => {
           onYearChange={vi.fn()}
         />,
       );
-      expect(screen.getByText('전체')).toHaveAttribute(
-        'aria-selected',
-        'false',
-      );
+      expect(screen.getByText('전체')).not.toHaveAttribute('aria-current');
     });
 
     it('활성 버튼은 tabIndex=0이다', () => {

--- a/src/features/award/ui/YearCategory.tsx
+++ b/src/features/award/ui/YearCategory.tsx
@@ -12,15 +12,14 @@ export function YearCategory({
   onYearChange,
 }: YearCategoryProps) {
   return (
-    <div className='award__year_category' role='tablist' aria-label='연도 필터'>
+    <nav className='award__year_category' aria-label='연도 필터'>
       {yearList.map((year) => {
         const isActive = activeYear === year;
         return (
           <button
             type='button'
-            role='tab'
             key={year}
-            aria-selected={isActive}
+            aria-current={isActive ? 'true' : undefined}
             tabIndex={isActive ? 0 : -1}
             className={isActive ? 'active' : ''}
             onClick={() => onYearChange(year)}
@@ -29,6 +28,6 @@ export function YearCategory({
           </button>
         );
       })}
-    </div>
+    </nav>
   );
 }

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -77,16 +77,21 @@ function Home() {
 
   return (
     <>
+      <a href='#main-content' className='skip-link'>
+        본문으로 바로 가기
+      </a>
       <Header />
-      <Hero showScrollArrow={isProduction} />
-      <Suspense fallback={null}>
-        <Vision />
-        <History />
-        <Award />
-        <Patent />
-        <Map />
-        <Footer />
-      </Suspense>
+      <main id='main-content'>
+        <Hero showScrollArrow={isProduction} />
+        <Suspense fallback={null}>
+          <Vision />
+          <History />
+          <Award />
+          <Patent />
+          <Map />
+          <Footer />
+        </Suspense>
+      </main>
     </>
   );
 }

--- a/src/shared/ui/ImageSlider/ui/ImageSlider.tsx
+++ b/src/shared/ui/ImageSlider/ui/ImageSlider.tsx
@@ -67,7 +67,7 @@ export function ImageSlider({
   }
 
   return (
-    <div className='image-slider'>
+    <div className='image-slider' role='region' aria-label='이미지 슬라이더'>
       <div
         className={`image-slider__frame${isDragging ? ' image-slider__frame--dragging' : ''}`}
         onTouchStart={handleTouchStart}
@@ -99,7 +99,7 @@ export function ImageSlider({
           onMouseLeave={onRelease}
           aria-label='이전 이미지'
         >
-          <IoIosArrowBack size='1.25vmax' />
+          <IoIosArrowBack size='1.25vmax' aria-hidden='true' />
         </button>
         <button
           className='image-slider__nav image-slider__nav--next'
@@ -108,9 +108,14 @@ export function ImageSlider({
           onMouseLeave={onRelease}
           aria-label='다음 이미지'
         >
-          <IoIosArrowForward size='1.25vmax' />
+          <IoIosArrowForward size='1.25vmax' aria-hidden='true' />
         </button>
-        <div className='image-slider__indicator'>
+        <div
+          className='image-slider__indicator'
+          aria-live='polite'
+          aria-atomic='true'
+        >
+          <span className='sr-only'>이미지</span>
           {currentIndex + 1} / {images.length}
         </div>
       </div>

--- a/src/shared/ui/InfoCard/ui/InfoCard.tsx
+++ b/src/shared/ui/InfoCard/ui/InfoCard.tsx
@@ -22,11 +22,14 @@ export function InfoCard({
       type='button'
       className={`info-card${className ? ` ${className}` : ''}`}
       onClick={onClick}
+      aria-label={`${title} - ${year.text}, ${secondary}`}
     >
       <div className='info-card__frame'>
         <div className='info-card__content'>
-          <div className='info-card__icon'>{icon}</div>
-          <div className='info-card__text'>
+          <div className='info-card__icon' aria-hidden='true'>
+            {icon}
+          </div>
+          <div className='info-card__text' aria-hidden='true'>
             <time className='info-card__text__year' dateTime={year.dateTime}>
               {year.text}
             </time>

--- a/src/shared/ui/Popup/ui/Popup.tsx
+++ b/src/shared/ui/Popup/ui/Popup.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect } from 'react';
+import { type ReactNode, useEffect, useRef } from 'react';
 import { IoMdClose } from 'react-icons/io';
 
 import '../styles/Popup.css';
@@ -16,6 +16,20 @@ export function Popup({
   onClose: () => void;
   children: ReactNode;
 }) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const triggerRef = useRef<Element | null>(null);
+
+  useEffect(() => {
+    triggerRef.current = document.activeElement;
+    closeButtonRef.current?.focus();
+
+    return () => {
+      if (triggerRef.current instanceof HTMLElement) {
+        triggerRef.current.focus();
+      }
+    };
+  }, []);
+
   useEffect(() => {
     document.body.style.overflow = 'hidden';
     history.pushState(null, '');
@@ -24,10 +38,16 @@ export function Popup({
       onClose();
     }
 
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+
     window.addEventListener('popstate', handlePopState);
+    window.addEventListener('keydown', handleKeyDown);
     return () => {
       document.body.style.overflow = '';
       window.removeEventListener('popstate', handlePopState);
+      window.removeEventListener('keydown', handleKeyDown);
     };
   }, [onClose]);
 
@@ -47,8 +67,13 @@ export function Popup({
       >
         <div className='popup__header'>
           {title && <h3 className='popup__title'>{title}</h3>}
-          <button aria-label='닫기' className='popup__close' onClick={onClose}>
-            <IoMdClose />
+          <button
+            ref={closeButtonRef}
+            aria-label='닫기'
+            className='popup__close'
+            onClick={onClose}
+          >
+            <IoMdClose aria-hidden='true' />
           </button>
         </div>
         {children}

--- a/src/shared/ui/SectionTitle/SectionTitle.tsx
+++ b/src/shared/ui/SectionTitle/SectionTitle.tsx
@@ -18,7 +18,7 @@ export function SectionTitle({
   return (
     <hgroup ref={ref} className={rootClass}>
       <div className='section-title__description'>
-        <hr />
+        <hr aria-hidden='true' />
         <p>{label}</p>
       </div>
       <h2>{heading}</h2>

--- a/src/widgets/award/ui/Award.test.tsx
+++ b/src/widgets/award/ui/Award.test.tsx
@@ -46,9 +46,11 @@ describe('Award', () => {
       );
     });
 
-    it('연도 필터(tablist)가 렌더링된다', () => {
+    it('연도 필터(navigation)가 렌더링된다', () => {
       render(<Award />);
-      expect(screen.getByRole('tablist')).toBeInTheDocument();
+      expect(
+        screen.getByRole('navigation', { name: '연도 필터' }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -108,7 +110,7 @@ describe('Award', () => {
     it('2008년 클릭 시 해당 연도(2개) 항목만 표시된다', () => {
       render(<Award />);
 
-      fireEvent.click(screen.getByRole('tab', { name: '2008' }));
+      fireEvent.click(screen.getByRole('button', { name: '2008' }));
 
       expect(document.querySelectorAll('button.award__card')).toHaveLength(2);
     });
@@ -116,7 +118,7 @@ describe('Award', () => {
     it('연도 변경 시 currentPage가 0으로 초기화된다', () => {
       render(<Award />);
 
-      fireEvent.click(screen.getByRole('tab', { name: '2008' }));
+      fireEvent.click(screen.getByRole('button', { name: '2008' }));
 
       const slider = document.querySelector(
         '.award__card_slider',
@@ -131,7 +133,7 @@ describe('Award', () => {
       render(<Award />);
 
       expect(
-        screen.getByRole('button', { name: 'Previous page' }),
+        screen.getByRole('button', { name: '이전 페이지' }),
       ).toBeInTheDocument();
     });
 
@@ -139,7 +141,7 @@ describe('Award', () => {
       render(<Award />);
 
       expect(
-        screen.queryByRole('button', { name: 'Previous page' }),
+        screen.queryByRole('button', { name: '이전 페이지' }),
       ).not.toBeInTheDocument();
     });
   });
@@ -181,7 +183,7 @@ describe('Award', () => {
         document.querySelector('.award__card_slider') as HTMLElement
       ).style.transform;
 
-      fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+      fireEvent.click(screen.getByRole('button', { name: '다음 페이지' }));
 
       const sliderAfter = (
         document.querySelector('.award__card_slider') as HTMLElement

--- a/src/widgets/award/ui/Award.tsx
+++ b/src/widgets/award/ui/Award.tsx
@@ -61,7 +61,7 @@ function Award() {
   const safePage = Math.min(currentPage, Math.max(0, totalPages - 1));
 
   return (
-    <section className='award'>
+    <section id='award' className='award' aria-label='수상 기록'>
       <div className='award__top'>
         <AwardTitle />
         <AwardCount awardList={AWARD_LIST} />
@@ -89,7 +89,14 @@ function Award() {
           />
         )}
         {selectedId !== null && (
-          <AwardPopup awardId={selectedId} onClose={handlePopupClose} />
+          <AwardPopup
+            awardId={selectedId}
+            awardTitle={
+              AWARD_LIST.find((a) => a.id === selectedId)?.title ??
+              '수상 이미지'
+            }
+            onClose={handlePopupClose}
+          />
         )}
       </div>
     </section>

--- a/src/widgets/award/ui/Count.tsx
+++ b/src/widgets/award/ui/Count.tsx
@@ -7,7 +7,7 @@ import '../styles/Count.css';
 export function AwardCount({ awardList }: { awardList: AwardItem[] }) {
   return (
     <div className='award__count'>
-      <FiAward className='award__count__icon' />
+      <FiAward className='award__count__icon' aria-hidden='true' />
       <p>총 {awardList.length}건의 표창 및 수상</p>
     </div>
   );

--- a/src/widgets/award/ui/Popup.stories.tsx
+++ b/src/widgets/award/ui/Popup.stories.tsx
@@ -9,6 +9,7 @@ const meta = {
   args: {
     onClose: fn(),
     awardId: 0,
+    awardTitle: '수상 이미지',
   },
   parameters: {
     layout: 'fullscreen',

--- a/src/widgets/award/ui/Popup.test.tsx
+++ b/src/widgets/award/ui/Popup.test.tsx
@@ -10,35 +10,37 @@ vi.mock('../model/image', () => ({
 describe('AwardPopup', () => {
   describe('렌더링', () => {
     it('dialog 역할로 렌더링된다', () => {
-      render(<AwardPopup awardId={1} onClose={vi.fn()} />);
+      render(<AwardPopup awardId={1} awardTitle='우수상' onClose={vi.fn()} />);
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
     it('aria-modal="true"가 설정된다', () => {
-      render(<AwardPopup awardId={1} onClose={vi.fn()} />);
+      render(<AwardPopup awardId={1} awardTitle='우수상' onClose={vi.fn()} />);
       expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
     });
 
-    it('aria-label="당선작 상세보기"가 설정된다', () => {
-      render(<AwardPopup awardId={1} onClose={vi.fn()} />);
+    it('aria-label에 수상 제목이 포함된다', () => {
+      render(<AwardPopup awardId={1} awardTitle='우수상' onClose={vi.fn()} />);
       expect(
-        screen.getByRole('dialog', { name: '당선작 상세보기' }),
+        screen.getByRole('dialog', { name: '우수상 수상 이미지' }),
       ).toBeInTheDocument();
     });
 
     it('닫기 버튼이 렌더링된다', () => {
-      render(<AwardPopup awardId={1} onClose={vi.fn()} />);
+      render(<AwardPopup awardId={1} awardTitle='우수상' onClose={vi.fn()} />);
       expect(screen.getByRole('button', { name: '닫기' })).toBeInTheDocument();
     });
 
-    it('이미지 alt 텍스트에 awardId가 포함된다', () => {
-      render(<AwardPopup awardId={3} onClose={vi.fn()} />);
-      expect(screen.getByAltText('당선작 3')).toBeInTheDocument();
+    it('이미지 alt 텍스트에 수상 제목이 포함된다', () => {
+      render(
+        <AwardPopup awardId={3} awardTitle='최우수상' onClose={vi.fn()} />,
+      );
+      expect(screen.getByAltText('최우수상')).toBeInTheDocument();
     });
 
     it('이미지 src가 getAwardImage 반환값이다', () => {
-      render(<AwardPopup awardId={1} onClose={vi.fn()} />);
-      expect(screen.getByAltText('당선작 1')).toHaveAttribute(
+      render(<AwardPopup awardId={1} awardTitle='우수상' onClose={vi.fn()} />);
+      expect(screen.getByAltText('우수상')).toHaveAttribute(
         'src',
         'popup-image.webp',
       );
@@ -48,7 +50,7 @@ describe('AwardPopup', () => {
   describe('닫기 동작', () => {
     it('닫기 버튼 클릭 시 onClose가 호출된다', () => {
       const onClose = vi.fn();
-      render(<AwardPopup awardId={1} onClose={onClose} />);
+      render(<AwardPopup awardId={1} awardTitle='우수상' onClose={onClose} />);
 
       fireEvent.click(screen.getByRole('button', { name: '닫기' }));
 
@@ -58,7 +60,7 @@ describe('AwardPopup', () => {
     it('오버레이 클릭 시 onClose가 호출된다', () => {
       const onClose = vi.fn();
       const { container } = render(
-        <AwardPopup awardId={1} onClose={onClose} />,
+        <AwardPopup awardId={1} awardTitle='우수상' onClose={onClose} />,
       );
       const overlay = container.querySelector('.popup__overlay')!;
 
@@ -69,7 +71,7 @@ describe('AwardPopup', () => {
 
     it('팝업 내부 클릭 시 onClose가 호출되지 않는다 (stopPropagation)', () => {
       const onClose = vi.fn();
-      render(<AwardPopup awardId={1} onClose={onClose} />);
+      render(<AwardPopup awardId={1} awardTitle='우수상' onClose={onClose} />);
 
       fireEvent.click(screen.getByRole('dialog'));
 

--- a/src/widgets/award/ui/Popup.tsx
+++ b/src/widgets/award/ui/Popup.tsx
@@ -4,18 +4,16 @@ import { getAwardImage } from '../model/image';
 
 export function AwardPopup({
   awardId,
+  awardTitle,
   onClose,
 }: {
   awardId: number;
+  awardTitle: string;
   onClose: () => void;
 }) {
   return (
-    <Popup ariaLabel='당선작 상세보기' onClose={onClose}>
-      <img
-        src={getAwardImage(awardId)}
-        alt={`당선작 ${awardId}`}
-        loading='lazy'
-      />
+    <Popup ariaLabel={`${awardTitle} 수상 이미지`} onClose={onClose}>
+      <img src={getAwardImage(awardId)} alt={awardTitle} loading='lazy' />
     </Popup>
   );
 }

--- a/src/widgets/award/ui/Viewport.tsx
+++ b/src/widgets/award/ui/Viewport.tsx
@@ -33,6 +33,8 @@ export function Viewport({
     <div
       ref={ref}
       className='award__card_viewport'
+      role='region'
+      aria-label='수상 목록'
       onTouchStart={onTouchStart}
       onTouchEnd={onTouchEnd}
     >

--- a/src/widgets/footer/ui/Footer.tsx
+++ b/src/widgets/footer/ui/Footer.tsx
@@ -35,7 +35,9 @@ export function Footer() {
               <span>대표이사</span>
               <span>{COMPANY.CEO}</span>
             </div>
-            <p className='footer__company_split'>|</p>
+            <p className='footer__company_split' aria-hidden='true'>
+              |
+            </p>
             <div className='footer__row'>
               <span>사업자 등록 번호</span>
               <span>{COMPANY.BUSINESS_NO}</span>
@@ -52,7 +54,9 @@ export function Footer() {
               <span>TEL</span>
               <span>{COMPANY.PHONE_DISPLAY}</span>
             </div>
-            <p className='footer__company_split'>|</p>
+            <p className='footer__company_split' aria-hidden='true'>
+              |
+            </p>
             <div className='footer__row'>
               <span>FAX</span>
               <span>{COMPANY.FAX}</span>

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -72,7 +72,7 @@ export function Header() {
       <button
         className='header__hamburger'
         onClick={() => setMenuOpen((prev) => !prev)}
-        aria-label='메뉴 열기'
+        aria-label={menuOpen ? '메뉴 닫기' : '메뉴 열기'}
         aria-expanded={menuOpen}
         aria-controls='mobile-menu'
       >

--- a/src/widgets/hero/ui/Hero.tsx
+++ b/src/widgets/hero/ui/Hero.tsx
@@ -12,7 +12,7 @@ const HeroBackground = lazy(() => import('./HeroBackground'));
 
 function Hero({ showScrollArrow }: { showScrollArrow: boolean }) {
   return (
-    <section className='hero'>
+    <section id='hero' className='hero' aria-label='회사 소개'>
       <Suspense
         fallback={
           <img

--- a/src/widgets/history/ui/Category.test.tsx
+++ b/src/widgets/history/ui/Category.test.tsx
@@ -11,14 +11,16 @@ const defaultProps = {
 
 describe('HistoryCategory', () => {
   describe('렌더링', () => {
-    it('tablist 역할로 렌더링된다', () => {
+    it('navigation 역할로 렌더링된다', () => {
       render(<HistoryCategory {...defaultProps} />);
-      expect(screen.getByRole('tablist')).toBeInTheDocument();
+      expect(
+        screen.getByRole('navigation', { name: '역사 카테고리' }),
+      ).toBeInTheDocument();
     });
 
-    it('INDEX_LIST 항목 수만큼 탭 버튼이 렌더링된다', () => {
+    it('INDEX_LIST 항목 수만큼 버튼이 렌더링된다', () => {
       render(<HistoryCategory {...defaultProps} />);
-      expect(screen.getAllByRole('tab')).toHaveLength(INDEX_LIST.length);
+      expect(screen.getAllByRole('button')).toHaveLength(INDEX_LIST.length);
     });
 
     it('각 카테고리 텍스트가 렌더링된다', () => {
@@ -35,20 +37,17 @@ describe('HistoryCategory', () => {
   });
 
   describe('활성 상태', () => {
-    it('tabActiveItem 버튼은 aria-selected=true이다', () => {
+    it('tabActiveItem 버튼은 aria-current=true이다', () => {
       render(<HistoryCategory {...defaultProps} tabActiveItem='Timeline' />);
       expect(screen.getByText('Timeline')).toHaveAttribute(
-        'aria-selected',
+        'aria-current',
         'true',
       );
     });
 
-    it('비활성 버튼은 aria-selected=false이다', () => {
+    it('비활성 버튼은 aria-current가 없다', () => {
       render(<HistoryCategory {...defaultProps} tabActiveItem='Timeline' />);
-      expect(screen.getByText('List')).toHaveAttribute(
-        'aria-selected',
-        'false',
-      );
+      expect(screen.getByText('List')).not.toHaveAttribute('aria-current');
     });
 
     it('활성 버튼에 active 클래스가 적용된다', () => {

--- a/src/widgets/history/ui/Category.tsx
+++ b/src/widgets/history/ui/Category.tsx
@@ -19,12 +19,11 @@ export function HistoryCategory({ tabActiveItem, navigateToCategory }: Props) {
   }
 
   return (
-    <div className='history__category' role='tablist'>
+    <nav className='history__category' aria-label='역사 카테고리'>
       {INDEX_LIST.map((item, index) => (
         <Fragment key={item}>
           <button
-            role='tab'
-            aria-selected={tabActiveItem === item}
+            aria-current={tabActiveItem === item ? 'true' : undefined}
             className={tabActiveItem === item ? 'active' : ''}
             onClick={() => handleCategoryClick(item)}
           >
@@ -33,6 +32,6 @@ export function HistoryCategory({ tabActiveItem, navigateToCategory }: Props) {
           {index < INDEX_LIST.length - 1 && <span aria-hidden='true'>|</span>}
         </Fragment>
       ))}
-    </div>
+    </nav>
   );
 }

--- a/src/widgets/history/ui/History.test.tsx
+++ b/src/widgets/history/ui/History.test.tsx
@@ -47,7 +47,7 @@ describe('History', () => {
 
   it('초기 상태에서 HistoryCategory의 List 탭이 active이다', () => {
     render(<History />);
-    const listTab = screen.getByRole('tab', { name: 'List' });
+    const listTab = screen.getByRole('button', { name: 'List' });
     expect(listTab).toHaveClass('active');
   });
 });

--- a/src/widgets/history/ui/History.tsx
+++ b/src/widgets/history/ui/History.tsx
@@ -325,7 +325,7 @@ function History() {
   const pageIsFlipping = !isCoverFlip && isFlipping;
 
   return (
-    <section className='history'>
+    <section id='history' className='history' aria-label='회사 역사'>
       <HistoryTitle />
       <HistoryCategory
         tabActiveItem={tabActiveItem}

--- a/src/widgets/history/ui/book/BackCover.tsx
+++ b/src/widgets/history/ui/book/BackCover.tsx
@@ -8,7 +8,7 @@ const COVER_MOVE_DURATION = 400;
 
 export function BackCoverInner() {
   return (
-    <div className='history__back-cover-inner'>
+    <div className='history__back-cover-inner' aria-hidden='true'>
       <hr className='history__back-cover-spine' />
       <div className='history__back-cover-content'>
         {WORDS.map((word) => (
@@ -35,10 +35,21 @@ export function BookBackCover({ onClick }: { onClick: () => void }) {
     setTimeout(onClick, COVER_MOVE_DURATION);
   }
 
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleClick();
+    }
+  }
+
   return (
     <div
       className={`history__back-cover${centered ? ' history__back-cover--centered' : ''}`}
+      role='button'
+      tabIndex={0}
+      aria-label='책 닫기'
       onClick={handleClick}
+      onKeyDown={handleKeyDown}
     >
       <BackCoverInner />
     </div>

--- a/src/widgets/history/ui/book/FrontCover.tsx
+++ b/src/widgets/history/ui/book/FrontCover.tsx
@@ -13,7 +13,7 @@ export function FrontCoverInner() {
   const years = new Date().getFullYear() - ESTABLISHED_YEAR;
 
   return (
-    <div className='history__front-cover-inner'>
+    <div className='history__front-cover-inner' aria-hidden='true'>
       <hr className='history__front-cover-spine' />
       <div className='history__front-cover-text'>
         <div className='history__front-cover-title'>
@@ -45,10 +45,21 @@ export function BookFrontCover({ onClick }: { onClick: () => void }) {
     setTimeout(onClick, COVER_MOVE_DURATION);
   }
 
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleClick();
+    }
+  }
+
   return (
     <div
       className={`history__front-cover${centered ? ' history__front-cover--centered' : ''}`}
+      role='button'
+      tabIndex={0}
+      aria-label='책 열기'
       onClick={handleClick}
+      onKeyDown={handleKeyDown}
     >
       <FrontCoverInner />
     </div>

--- a/src/widgets/history/ui/book/content_container/Content.tsx
+++ b/src/widgets/history/ui/book/content_container/Content.tsx
@@ -110,7 +110,7 @@ function ContentItem({
           onClick={handleImageClick}
           aria-label='이미지 보기'
         >
-          <MdOutlineImage size={18} color='white' />
+          <MdOutlineImage size={18} color='white' aria-hidden='true' />
         </button>
       )}
       <div className='content__text' ref={textRef}>
@@ -162,7 +162,7 @@ function ContentItem({
           {imageSrc && (
             <>
               <img src={imageSrc} alt={item.title} loading='lazy' />
-              <div className='content__image-zoom'>
+              <div className='content__image-zoom' aria-hidden='true'>
                 <MdOutlineZoomOutMap size='1.25vmax' color='white' />
               </div>
             </>

--- a/src/widgets/map/ui/Map.test.tsx
+++ b/src/widgets/map/ui/Map.test.tsx
@@ -77,7 +77,9 @@ describe('Map', () => {
       setNaverMaps(false);
       render(<Map />);
 
-      expect(screen.getByTitle('위치 지도')).toBeInTheDocument();
+      expect(
+        screen.getByTitle('인들이앤에이치 본사 위치 지도'),
+      ).toBeInTheDocument();
       expect(mockMakeMap).not.toHaveBeenCalled();
     });
 
@@ -99,7 +101,9 @@ describe('Map', () => {
 
       // queueMicrotask로 지연된 setState 완료를 기다림
       await waitFor(() => {
-        expect(screen.getByTitle('위치 지도')).toBeInTheDocument();
+        expect(
+          screen.getByTitle('인들이앤에이치 본사 위치 지도'),
+        ).toBeInTheDocument();
       });
     });
   });
@@ -119,7 +123,9 @@ describe('Map', () => {
       const { container } = render(<Map />);
 
       expect(container.querySelector('.map__content')).toBeInTheDocument();
-      expect(screen.queryByTitle('위치 지도')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTitle('인들이앤에이치 본사 위치 지도'),
+      ).not.toBeInTheDocument();
     });
 
     it('API 키가 있고 Naver SDK 미로드 시 스크립트가 동적으로 삽입된다', () => {
@@ -148,7 +154,9 @@ describe('Map', () => {
       script?.dispatchEvent(new Event('error'));
 
       await waitFor(() => {
-        expect(screen.getByTitle('위치 지도')).toBeInTheDocument();
+        expect(
+          screen.getByTitle('인들이앤에이치 본사 위치 지도'),
+        ).toBeInTheDocument();
       });
     });
   });
@@ -162,7 +170,9 @@ describe('Map', () => {
 
       rerender(<Map />);
 
-      expect(screen.getByTitle('위치 지도')).toBeInTheDocument();
+      expect(
+        screen.getByTitle('인들이앤에이치 본사 위치 지도'),
+      ).toBeInTheDocument();
     });
 
     it('마운트 시 navermap_authFailure 콜백이 등록된다', () => {

--- a/src/widgets/map/ui/Map.tsx
+++ b/src/widgets/map/ui/Map.tsx
@@ -98,18 +98,23 @@ function Map() {
   }, [mapState]);
 
   return (
-    <section className='map'>
+    <section id='map' className='map' aria-label='찾아오시는 길'>
       <MapTitle />
       <div className='map__card'>
         {mapState === 'fallback' ? (
           <iframe
             className='map__content map__content--fallback'
             src={FALLBACK_MAP_URL}
-            title='위치 지도'
+            title='인들이앤에이치 본사 위치 지도'
             loading='lazy'
           />
         ) : (
-          <div ref={mapRef} className='map__content' />
+          <div
+            ref={mapRef}
+            className='map__content'
+            role='img'
+            aria-label='인들이앤에이치 본사 위치 지도'
+          />
         )}
         <MapCard />
       </div>

--- a/src/widgets/patent/ui/ExpireContent.tsx
+++ b/src/widgets/patent/ui/ExpireContent.tsx
@@ -9,7 +9,10 @@ export function PatentExpireContent() {
     <article className='patent__expiration'>
       <header className='patent__expiration__title'>
         <div className='patent__expiration__title__text'>
-          <FaRegFileExcel className='patent__expiration__icon' />
+          <FaRegFileExcel
+            className='patent__expiration__icon'
+            aria-hidden='true'
+          />
           <h3>만료 특허 이력 ({PATENT_EXPIRE_LIST.length}건)</h3>
         </div>
         <hr />

--- a/src/widgets/patent/ui/Patent.tsx
+++ b/src/widgets/patent/ui/Patent.tsx
@@ -5,7 +5,7 @@ import { PatentValidContent } from './ValidContent';
 
 function Patent() {
   return (
-    <section className='patent'>
+    <section id='patent' className='patent' aria-label='특허 기록'>
       <PatentTitle />
       <PatentValidContent />
       <PatentExpireContent />

--- a/src/widgets/patent/ui/ValidContent.tsx
+++ b/src/widgets/patent/ui/ValidContent.tsx
@@ -34,7 +34,10 @@ export function PatentValidContent() {
     <article className='patent__content'>
       <header className='patent__content__title'>
         <div className='patent__content__title__text'>
-          <FaRegCheckCircle className='patent__content__icon' />
+          <FaRegCheckCircle
+            className='patent__content__icon'
+            aria-hidden='true'
+          />
           <h3>유효 특허증 ({PATENT_VALID_LIST.length}건)</h3>
         </div>
         <hr />

--- a/src/widgets/vision/ui/Vision.tsx
+++ b/src/widgets/vision/ui/Vision.tsx
@@ -66,7 +66,7 @@ export function Vision() {
   }, []);
 
   return (
-    <section className='vision'>
+    <section id='vision' className='vision' aria-label='미래 비전'>
       <VisionTitle ref={titleRef} />
       <div className='vision__main'>
         {VISION_DATA.map((item, index) => (

--- a/src/widgets/vision/ui/VisionItem.tsx
+++ b/src/widgets/vision/ui/VisionItem.tsx
@@ -64,7 +64,7 @@ export function VisionItem({
             <h3>{keyword}</h3>
             <h4>{title}</h4>
           </div>
-          <hr />
+          <hr aria-hidden='true' />
         </div>
         <p className='vision__content__description'>{description}</p>
       </div>


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #152 

### 스크린 리더 & ARIA 접근성 개선 작업

시각 장애인이 스크린 리더로 사이트를 탐색할 수 있도록 전체 페이지에 걸쳐 ARIA 속성, 시맨틱 태그, 포커스 관리를 추가했습니다.

**고민했던 점:**
- `role="tablist"` 는 반드시 `role="tabpanel"` 과 쌍을 이루어야 의미가 완성됩니다. `HistoryCategory`와 `YearCategory`는 tabpanel 없이 tablist를 쓰고 있었기 때문에, `<nav>` + `aria-current` 패턴으로 교체했습니다.
- 팝업(`Popup`) 컴포넌트는 열릴 때 닫기 버튼으로 포커스를 이동하고, 닫힐 때 이전 트리거 요소로 포커스를 복원하여 스크린 리더 사용자가 맥락을 잃지 않도록 처리했습니다.
- 히스토리 책 커버(`BookFrontCover`, `BookBackCover`)는 클릭만 가능한 `<div>` 였기 때문에, `role="button"` + `tabIndex={0}` + `onKeyDown(Enter/Space)` 를 추가해 키보드로도 조작 가능하게 했습니다.

### 핵심 변화

#### 변경 전
- 스크린 리더가 페이지 구조를 파악할 랜드마크 없음
- 장식 아이콘/구분자가 스크린 리더에 그대로 읽힘
- 팝업 열릴 때 포커스 이동 없어 탐색 맥락 단절
- `role="tablist"` 가 tabpanel 없이 불완전하게 사용됨
- 카드 버튼의 accessible name이 아이콘 포함 중복 텍스트

#### 변경 후
- `<main id="main-content">` 랜드마크 + **본문 바로가기** skip link 추가
- 모든 섹션에 `id` + `aria-label` 설정 (skip link 타겟 포함)
- 장식 요소 전부 `aria-hidden="true"` 처리
- 팝업: 열림 시 닫기 버튼 포커스 → 닫힘 시 트리거 복원 + `Escape` 키 지원
- tablist → `<nav>` + `aria-current="true"` 전환
- 책 커버 div → `role="button"` + 키보드 지원

# 📋 작업 내용

## 1. 랜드마크 구조 (`Home.tsx`, `index.css`)
- `<main id="main-content">` 으로 Hero~Footer 전 섹션 감쌈
- `.skip-link` : 포커스 시 화면에 표시되는 **본문 바로가기** 링크 추가

## 2. 섹션 id + aria-label 설정
| 섹션 | id | aria-label |
|------|-----|------------|
| Hero | `hero` | `회사 소개` |
| Vision | `vision` | `미래 비전` |
| History | `history` | `회사 역사` |
| Award | `award` | `수상 기록` |
| Patent | `patent` | `특허 기록` |
| Map | `map` | `찾아오시는 길` |

## 3. 헤더 (`Header.tsx`)
- 햄버거 버튼 `aria-label`: `"메뉴 열기"` ↔ `"메뉴 닫기"` 동적 전환 (기존 고정값)

## 4. 팝업 (`Popup.tsx`)
- `useRef`로 트리거 요소 저장 → 닫힐 때 포커스 복원
- 마운트 시 `closeButtonRef.current?.focus()` 로 닫기 버튼 자동 포커스
- `window.addEventListener('keydown')` 로 `Escape` 키 닫기 지원
- `<IoMdClose>` 에 `aria-hidden="true"` 추가

## 5. 장식 요소 `aria-hidden` 처리
- `SectionTitle` 구분선 `<hr>`
- `VisionItem` 구분선 `<hr>`
- `AwardCount`, `PatentValidContent`, `PatentExpireContent` 아이콘
- Footer `|` 구분자 `<p>`
- `BackCoverInner`, `FrontCoverInner` 내부 장식 텍스트
- `Content.tsx` 줌 오버레이, `MdOutlineImage` 아이콘

## 6. 카드 / 슬라이더 접근성 (`InfoCard`, `ImageSlider`, `Viewport`)
- `InfoCard` 버튼: `aria-label="{제목} - {연도}, {발행처}"` + 내부 시각 요소 `aria-hidden`
- `ImageSlider`: `role="region" aria-label="이미지 슬라이더"` + 인디케이터 `aria-live="polite" aria-atomic="true"`
- `Viewport`: `role="region" aria-label="수상 목록"`

## 7. 카테고리 nav 전환 (`Category.tsx`, `YearCategory.tsx`)
- `role="tablist"` + `role="tab"` + `aria-selected` → `<nav>` + `aria-current="true"` 로 교체
  - tabpanel 없는 불완전한 ARIA 패턴 해소

## 8. 책 커버 키보드 접근성 (`FrontCover.tsx`, `BackCover.tsx`)
- 클릭만 되던 `<div>` → `role="button"` + `tabIndex={0}` + `aria-label` + `onKeyDown(Enter/Space)`

## 9. 페이지네이션 (`Pagination.tsx`)
- `aria-label` 영문 → 한국어 (`Previous page` → `이전 페이지` 등)
- 페이지 인디케이터 `aria-live="polite"` + `sr-only` 텍스트로 현재 페이지 낭독

## 10. AwardPopup alt 텍스트
- `"당선작 {id}"` (id 숫자) → 실제 수상 제목으로 개선
- `Popup.test.tsx`, `Popup.stories.tsx` 도 함께 업데이트

# 📷 스크린 샷 (선택 사항)

해당 없음 (ARIA/접근성 변경은 시각적 변화 없음)