### PR TITLE
⚙️ chore: Claude Code 지침서 및 명령어 개선

### DIFF
--- a/.claude/agents/vitest-writer.md
+++ b/.claude/agents/vitest-writer.md
@@ -9,18 +9,18 @@ memory: project
 You are a senior front-end test engineer specializing in Vitest and React Testing Library for production-grade TypeScript/React applications. You write precise, maintainable, and comprehensive tests that validate behavior — not implementation details.
 
 **모든 응답은 한국어로 작성하세요. 단, 기술 용어(함수명, 파일 경로, 코드 등)는 영어를 유지합니다.**
+**테스트는 오로지 컴포넌트 테스트와 비즈니스 로직 테스트는 model 파일과 유틸리티 함수에 한정합니다.**
 
-## 프로젝트 컨텍스트
-
-이 프로젝트는 도시경관, 외장 디자인, 엔지니어링 투자 회사 웹사이트입니다.
+When invoked, follow these steps:
 
 **Tech Stack**:
 
-- React 19.2.0 (React Compiler 활성화)
+- React 19.2.5 (React Compiler 활성화)
 - Vite (rolldown-vite@7.2.5)
 - TypeScript 5.9.3 (strict mode)
 - Three.js (Hero 섹션 wave 애니메이션)
 - Vitest (테스트 프레임워크)
+- Storybook (UI 컴포넌트 명세화 및 테스트)
 
 **아키텍처**: FSD (Feature-Sliced Design)
 
@@ -29,11 +29,18 @@ src/
   app/ → pages/ → widgets/ → features/ → entities/ → shared/
 ```
 
-**스타일링**: Plain CSS (`.css` files), CSS Modules 사용 금지
+**스타일링**: Plain CSS (`.css` files), index.css로부터 상속
+
+## 테스트 관련 명령
+
+npm run test - 컴포넌트 및 유틸리티 테스트 실행
+npm run test:coverage - 테스트 커버리지 보고서 생성
+npm run test:storybook - Storybook과 통합된 테스트 실행
 
 ## 테스트 파일 위치 규칙
 
 FSD 슬라이스 내에 테스트를 공배치(co-locate)하세요:
+소스코드 1:1 대응 테스트 파일
 
 ```
 src/
@@ -84,7 +91,7 @@ src/
 ### 4. Three.js 관련 코드 테스트
 
 - Three.js 객체는 mock 처리
-- DOM API (canvas, WebGL context)는 vi.mock() 또는 jsdom 활용
+- DOM API (canvas, WebGL context)는 vi.mock() 또는 happy dom 활용
 - 복잡한 3D 로직보다 설정값, 파라미터 전달, 함수 호출 여부에 집중
 
 ### 5. TypeScript 준수 사항
@@ -164,7 +171,7 @@ vi.spyOn(module, 'functionName').mockReturnValue(expectedValue);
 
 테스트 파일 제출 전 자가 검토:
 
-- [ ] TypeScript strict mode 컴파일 에러 없음
+- [ ] TypeScript strict mode 컴파일, Lint 에러 없음
 - [ ] 모든 import가 실제 존재하는 파일/모듈을 참조
 - [ ] `import type` 사용으로 `verbatimModuleSyntax` 준수
 - [ ] 사용하지 않는 변수/파라미터 없음

--- a/.claude/commands/ai-update.md
+++ b/.claude/commands/ai-update.md
@@ -2,6 +2,30 @@ Update `CLAUDE.md` to reflect the current state of the codebase.
 
 ---
 
+## Global Rules
+
+### AI Identity
+
+- The AI must act as a **CTO-level front-end engineer and product designer**
+- It must provide interfaces that are **effective, scalable, and sustainable over time**
+
+---
+
+### Command Execution Rule
+
+- Before executing any command, **rtk must be used**
+- This rule applies to all steps without exception
+
+---
+
+### Document Integrity Rule
+
+- Do NOT break or alter the existing structure or format of `CLAUDE.md`
+- Preserve all section ordering, formatting, and conventions
+- Apply only minimal, necessary changes within the existing rules
+
+---
+
 ## Step 1: Scan the codebase
 
 Run these commands in parallel:
@@ -15,6 +39,9 @@ cat package.json
 
 # Vite config (for Build System / Development Server)
 cat vite.config.ts
+
+# Test Config
+cat vitest.config.ts
 ```
 
 ## Step 2: Identify what has changed
@@ -24,6 +51,7 @@ Compare the scan results against the current `CLAUDE.md` and identify:
 1. **Project Structure** — files or directories added/removed under `src/`
 2. **Tech Stack** — new or removed packages in `package.json` that are user-facing (ignore dev tooling already listed)
 3. **Build System / Development Server** — any changes in `vite.config.ts`
+4. **Test System** - any changes in `vitest.config.ts`
 
 Do NOT change sections that have not actually changed.
 
@@ -53,3 +81,7 @@ Apply only the changes identified in Step 2.
 ## Step 4: Confirm
 
 After editing, briefly summarize in Korean what was updated and what was left unchanged.
+
+```
+
+```

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -36,6 +36,7 @@ gh issue list -R Induel-E-H/web-FE --state open --json number,title,labels --lim
 - `🔧 Chore` — settings / config
 - `🔨 Refactor` — code restructuring
 - `🧹 Cleanup` — code cleanup
+- `⚡️ Performance` — Performance Improvement
 
 **Related Issues** — match the changes to open issues in `Induel-E-H/web-FE`.
 
@@ -62,47 +63,3 @@ gh pr create \
 EOF
 )"
 ```
-
-## Step 5: Update Project End Date (only when `close #N` is used)
-
-For each closed issue, update its End Date in the GitHub Project (project number: **1**) to today's date.
-
-**5-1. Fetch project node ID, End Date field ID, and issue item ID in one query** (replace `ISSUE_NUMBER`):
-
-```bash
-gh api graphql -f query='
-{
-  organization(login: "Induel-E-H") {
-    projectV2(number: 1) {
-      id
-      fields(first: 30) {
-        nodes {
-          __typename
-          ... on ProjectV2Field {
-            id
-            name
-          }
-        }
-      }
-    }
-  }
-  repository(owner: "Induel-E-H", name: "web-FE") {
-    issue(number: ISSUE_NUMBER) {
-      projectItems(first: 10) {
-        nodes {
-          id
-          project { number }
-        }
-      }
-    }
-  }
-}'
-```
-
-From the response, extract:
-
-- `organization.projectV2.id` → `PROJECT_ID`
-- The field node whose `name` matches "End Date" (or similar) → `END_DATE_FIELD_ID`
-- The `projectItems` node where `project.number == 1` → `ITEM_ID`
-
-If there are multiple closed issues, repeat Steps 5-1 for each one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,28 @@ A website for an urban landscape, exterior design, and engineering investment co
 
 ## Development
 
-npm run dev # Start dev server on port 5173
-npm run build # TypeScript check + production build
+npm run dev # Start dev server on port 5173 (all widgets)
+npm run dev:hero # Hero widget only
+npm run dev:vision # Vision widget only
+npm run dev:history # History widget only
+npm run dev:award # Award widget only
+npm run dev:patent # Patent widget only
+npm run dev:map # Map widget only
+npm run dev:footer # Footer widget only
+npm run build # Alias for build:staging
+npm run build:staging # TypeScript check + staging build
+npm run build:prod # TypeScript check + production build
 npm run preview # Preview production build
 npm run lint # Run ESLint
 npm run format # Format code with Prettier
+
+## Testing
+
+npm run test # Run unit tests (Vitest)
+npm run test:ui # Run unit tests with Vitest UI
+npm run test:coverage # Run unit tests with coverage report
+npm run storybook # Start Storybook on port 6006
+npm run test:storybook # Run Storybook interaction tests (Playwright)
 
 ## Docker
 
@@ -65,10 +82,14 @@ Example: `feat/hero-section`, `fix/map-marker-crash`
 
 # Tech Stack
 
-- React 19.2.0 (React Compiler Enabled)
+- React 19.2.5 (React Compiler Enabled)
 - Vite (rolldown-vite@7.2.5)
 - TypeScript 5.9.3
-- Three.js — 3D wave background animation in the Hero section (`src/shared/lib/three/`)
+- Three.js ^0.184.0 — 3D wave background animation in the Hero section (`src/shared/lib/three/`)
+- react-router-dom ^7.14.2 — client-side routing
+- react-icons ^5.6.0 — icon library
+- Vitest ^4.1.2 — unit and component testing
+- Storybook ^10.3.5 — component documentation and visual/interaction testing
 - ESLint
 - Prettier
 
@@ -80,6 +101,17 @@ Example: `feat/hero-section`, `fix/map-marker-crash`
 - **React Compiler**: Enabled via `babel-plugin-react-compiler` in `vite.config.ts`
   - Automatically optimizes React components
   - Impacts dev and build performance but improves runtime performance
+- **Plugins**: `vite-tsconfig-paths` for TypeScript path aliases; `vite-plugin-sitemap` for SEO sitemap generation (`https://induel.co.kr`)
+- **Manual chunks**: `vendor-three` (Three.js) and `vendor-react` (React/React DOM/React Router) split for better caching
+
+## Testing
+
+Configured in `vitest.config.ts` with two projects:
+
+- **`unit`**: runs in `happy-dom`, includes `src/**/*.test.{ts,tsx}`, setup file at `src/test/setup.ts`
+- **`storybook`**: runs in Playwright Chromium (headless), driven by `@storybook/addon-vitest`
+
+Coverage uses `v8` provider; reports to `text` and `json-summary`.
 
 ## TypeScript Configuration
 
@@ -117,59 +149,199 @@ Both configs use:
 
 ```
 src/
-  ├── main.tsx                          # Entry point (React 19 StrictMode)
-  ├── app/                              # App layer
-  │   ├── App.tsx                       # Root component
-  │   ├── providers/                    # App-level providers
+  ├── main.tsx                             # Entry point (React 19 StrictMode)
+  ├── vite-env.d.ts
+  ├── app/                                 # App layer
+  │   ├── App.tsx                          # Root component
   │   └── styles/
-  │       ├── fonts.css                 # Font definitions
-  │       └── index.css                 # Global styles
-  ├── pages/                            # Pages layer
-  │   └── home/
-  │       ├── Home.tsx
+  │       ├── fonts.css                    # Font definitions
+  │       └── index.css                    # Global styles
+  ├── pages/                               # Pages layer
+  │   ├── home/
+  │   │   ├── Home.tsx
+  │   │   └── index.ts
+  │   └── privacy-policy/
+  │       ├── PrivacyPolicy.tsx
+  │       ├── styles/PrivacyPolicy.css
   │       └── index.ts
-  ├── widgets/                          # Widgets layer
-  │   ├── hero/                         # Hero section (Page 1)
+  ├── widgets/                             # Widgets layer
+  │   ├── hero/                            # Hero section (Page 1)
   │   │   ├── ui/
   │   │   │   ├── Hero.tsx
-  │   │   │   └── HeroBackground.tsx    # Three.js wave background
+  │   │   │   └── HeroBackground.tsx       # Three.js wave background
+  │   │   ├── model/
+  │   │   │   ├── heroConfig.ts
+  │   │   │   └── useWaveBackground.ts
   │   │   ├── styles/Hero.css
   │   │   └── index.ts
-  │   ├── footer/                       # Footer (Page 7)
-  │   │   ├── ui/Footer.tsx
-  │   │   ├── styles/Footer.css
+  │   ├── header/                          # Global navigation header
+  │   │   ├── ui/Header.tsx
+  │   │   ├── model/
+  │   │   │   ├── navItems.ts
+  │   │   │   ├── useHeaderVisibility.ts
+  │   │   │   ├── useIsHero.ts
+  │   │   │   └── useScrollDirection.ts
+  │   │   └── styles/Header.css
+  │   ├── vision/                          # Future Vision (Pages 2-4)
+  │   │   ├── ui/
+  │   │   │   ├── Vision.tsx
+  │   │   │   ├── VisionItem.tsx
+  │   │   │   └── VisionTitle.tsx
+  │   │   ├── styles/
+  │   │   │   ├── Vision.css
+  │   │   │   ├── VisionItem.css
+  │   │   │   └── VisionTitle.css
   │   │   └── index.ts
-  │   ├── map/                          # Map & Directions (Page 7)
-  │   │   ├── ui/Map.tsx
+  │   ├── history/                         # Company History (Page 5) — book-flip UI
+  │   │   ├── ui/
+  │   │   │   ├── book/
+  │   │   │   │   ├── content_container/   # Content, List, Milestones, Timeline
+  │   │   │   │   ├── BackCover.tsx
+  │   │   │   │   ├── BookPageSide.tsx
+  │   │   │   │   ├── BookSide.tsx
+  │   │   │   │   ├── Cover.tsx
+  │   │   │   │   ├── CoverFlip.tsx
+  │   │   │   │   ├── FrontCover.tsx
+  │   │   │   │   ├── PageFlip.tsx
+  │   │   │   │   └── PageTitle.tsx
+  │   │   │   ├── Category.tsx
+  │   │   │   ├── History.tsx
+  │   │   │   ├── HistoryTitle.tsx
+  │   │   │   └── ImageGalleryPopup.tsx
+  │   │   ├── styles/
+  │   │   │   ├── book/                    # Per-component book CSS files
+  │   │   │   ├── Category.css
+  │   │   │   ├── History.css
+  │   │   │   ├── HistoryTitle.css
+  │   │   │   └── ImageGalleryPopup.css
+  │   │   └── index.ts
+  │   ├── award/                           # Awards (Page 6)
+  │   │   ├── ui/
+  │   │   │   ├── Award.tsx
+  │   │   │   ├── AwardTitle.tsx
+  │   │   │   ├── Card.tsx
+  │   │   │   ├── Count.tsx
+  │   │   │   ├── Popup.tsx
+  │   │   │   └── Viewport.tsx
+  │   │   ├── model/
+  │   │   │   ├── image.ts
+  │   │   │   └── responsive.ts
+  │   │   ├── styles/
+  │   │   └── index.ts
+  │   ├── patent/                          # Patents (Page 6)
+  │   │   ├── ui/
+  │   │   │   ├── Card.tsx
+  │   │   │   ├── ExpireContent.tsx
+  │   │   │   ├── Patent.tsx
+  │   │   │   ├── PatentTitle.tsx
+  │   │   │   └── ValidContent.tsx
+  │   │   ├── styles/
+  │   │   └── index.ts
+  │   ├── map/                             # Map & Directions (Page 7)
+  │   │   ├── ui/
+  │   │   │   ├── Map.tsx
+  │   │   │   ├── MapCard.tsx
+  │   │   │   └── MapTitle.tsx
   │   │   ├── model/
   │   │   │   ├── map.ts
   │   │   │   ├── mapInfoCard.ts
-  │   │   │   ├── mapMarker.ts
-  │   │   │   └── transportInfo.ts
+  │   │   │   └── mapMarker.ts
   │   │   ├── styles/
   │   │   └── index.ts
-  │   └── header/                       # Header (WIP)
-  ├── features/                         # Features layer (WIP)
-  ├── entities/                         # Entities layer (WIP)
-  └── shared/                           # Shared layer
-      ├── assets/
-      │   ├── images/
-      │   └── induel-icon.svg
-      ├── config/
-      ├── constant/
-      │   ├── company.ts                # Company info constants
-      │   └── index.ts
-      ├── lib/
-      │   └── three/                    # Three.js utilities
-      │       ├── animation/waveAnimation.ts
-      │       ├── core/
-      │       │   ├── createCamera.ts
-      │       │   ├── createLights.ts
-      │       │   ├── createRenderer.ts
-      │       │   └── createScene.ts
-      │       ├── objects/
-      │       │   ├── createWaveTubes.ts
-      │       │   └── type.ts
-      │       └── utils/attachResizeHandler.ts
-      └── ui/                           # Shared UI components (WIP)
+  │   └── footer/                          # Footer (Page 7)
+  │       ├── ui/Footer.tsx
+  │       ├── styles/Footer.css
+  │       └── index.ts
+  ├── features/                            # Features layer
+  │   ├── award/                           # Award year-filter & pagination
+  │   │   ├── ui/
+  │   │   │   ├── Pagination.tsx
+  │   │   │   └── YearCategory.tsx
+  │   │   ├── model/
+  │   │   │   ├── constant.ts
+  │   │   │   ├── pagination.ts
+  │   │   │   └── useYearFilter.ts
+  │   │   ├── styles/
+  │   │   └── index.ts
+  │   └── history/                         # History book navigation logic
+  │       ├── model/
+  │       │   ├── animation/
+  │       │   │   ├── buildRapidSteps.ts
+  │       │   │   ├── useFlipAnimation.ts
+  │       │   │   └── useRapidFlip.ts
+  │       │   ├── events/useHoldNavigation.ts
+  │       │   ├── constants.ts
+  │       │   ├── helpers.ts
+  │       │   ├── pageRegistry.ts
+  │       │   ├── types.ts
+  │       │   ├── useBookCoverState.ts
+  │       │   └── useBookNavigation.ts
+  │       └── index.ts
+  ├── entities/                            # Entities layer
+  │   ├── award/
+  │   │   ├── model/
+  │   │   │   ├── awardList.ts
+  │   │   │   └── types.ts
+  │   │   └── index.ts
+  │   ├── history/
+  │   │   ├── model/
+  │   │   │   ├── artworkData.ts
+  │   │   │   ├── milestonesData.ts
+  │   │   │   └── timelineData.ts
+  │   │   └── index.ts
+  │   ├── map/
+  │   │   ├── model/transportInfo.ts
+  │   │   └── index.ts
+  │   ├── patent/
+  │   │   ├── model/patentListData.ts
+  │   │   └── index.ts
+  │   └── vision/
+  │       ├── model/visionData.ts
+  │       └── index.ts
+  ├── shared/                              # Shared layer
+  │   ├── assets/
+  │   │   ├── fonts/                       # Pretendard & BookendBatang subset woff2 + CSS
+  │   │   └── induel-icon.svg
+  │   ├── constant/
+  │   │   ├── company.ts                   # Company info constants
+  │   │   └── index.ts
+  │   ├── lib/
+  │   │   ├── breakpoint/useBreakpoint.ts  # Responsive breakpoint hook
+  │   │   ├── console/banner.ts            # Console branding banner
+  │   │   ├── ordinal/getOrdinalSuffix.ts
+  │   │   ├── scroll/smoothScrollTo.ts
+  │   │   ├── three/                       # Three.js utilities
+  │   │   │   ├── animation/waveAnimation.ts
+  │   │   │   ├── core/
+  │   │   │   │   ├── createCamera.ts
+  │   │   │   │   ├── createLights.ts
+  │   │   │   │   ├── createRenderer.ts
+  │   │   │   │   └── createScene.ts
+  │   │   │   ├── objects/
+  │   │   │   │   ├── createWaveTubes.ts
+  │   │   │   │   └── type.ts
+  │   │   │   └── utils/attachResizeHandler.ts
+  │   │   ├── useScrollLock/useScrollLock.ts
+  │   │   └── useSlideGesture/useSlideGesture.ts
+  │   └── ui/                              # Shared UI components
+  │       ├── ImageSlider/
+  │       │   ├── ui/ImageSlider.tsx
+  │       │   ├── model/useSliderNavigation.ts
+  │       │   ├── styles/ImageSlider.css
+  │       │   └── index.ts
+  │       ├── InfoCard/
+  │       │   ├── ui/InfoCard.tsx
+  │       │   ├── styles/InfoCard.css
+  │       │   └── index.ts
+  │       ├── Popup/
+  │       │   ├── ui/Popup.tsx
+  │       │   ├── styles/Popup.css
+  │       │   └── index.ts
+  │       └── SectionTitle/
+  │           ├── SectionTitle.tsx
+  │           ├── SectionTitle.css
+  │           └── index.ts
+  └── test/
+      ├── setup.ts                         # Vitest global setup
+      └── vitest.d.ts
 ```


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- #47 

### Claude Code 지침서 개선

- 프로젝트가 크게 성장하면서 `CLAUDE.md`가 실제 코드베이스 상태와 맞지 않아 업데이트
- `vitest-writer` 에이전트 지침서가 현재 테스트 환경을 제대로 반영하지 못해 개선
- `pr` 명령어에서 불필요한 issue close 자동화 및 end-date 업데이트 로직 제거
- `ai-update` 명령어 신규 작성으로 향후 CLAUDE.md 갱신 프로세스 표준화

### 핵심 변화

#### 변경 전

- `CLAUDE.md`에 `features`, `entities` 레이어가 WIP로 표시되고, 실제 구현된 위젯/엔티티/피처들이 누락
- tech stack에 `react-router-dom`, `react-icons`, `Vitest`, `Storybook` 미등재
- 개별 위젯 dev 서버 명령어 및 테스트 명령어 미기재

#### 변경 후

- `CLAUDE.md` Project Structure 전면 재생성 — 모든 FSD 레이어(features, entities, widgets, shared/ui) 반영
- Tech Stack 업데이트 (React 19.2.5, react-router-dom, react-icons, Vitest, Storybook 추가)
- Commands에 위젯별 dev 서버(`dev:hero` 등 7종), 빌드 변형(`build:staging`/`build:prod`), 테스트/Storybook 명령어 추가
- Architecture에 Testing 섹션 신규 추가 (vitest.config.ts의 unit/storybook 프로젝트 구조 설명)
- Build System에 `vite-plugin-sitemap`, `vite-tsconfig-paths`, manual chunk 분리 정보 추가

# 📋 작업 내용

- `CLAUDE.md`: 프로젝트 전체 상태 반영 업데이트 (Project Structure, Tech Stack, Commands, Architecture)
- `.claude/commands/ai-update.md`: CLAUDE.md 갱신 표준 명령어 신규 작성
- `.claude/agents/vitest-writer.md`: Vitest 프로젝트 구조(unit/storybook 분리) 및 테스트 작성 지침 개선
- `.claude/commands/pr.md`: issue close 자동화 및 end-date 로직 제거로 명령어 단순화