### PR TITLE
🔨 refactor: viewport 판별 헬퍼 추출 및 heroConfig 데드 코드 제거

### DIFF
--- a/src/shared/lib/breakpoint/viewport.ts
+++ b/src/shared/lib/breakpoint/viewport.ts
@@ -1,0 +1,9 @@
+import { BREAKPOINT_MOBILE_MAX, BREAKPOINT_TABLET_MAX } from './useBreakpoint';
+
+export function isMobileViewport(): boolean {
+  return window.innerWidth <= BREAKPOINT_MOBILE_MAX;
+}
+
+export function isTabletViewport(): boolean {
+  return window.innerWidth <= BREAKPOINT_TABLET_MAX;
+}

--- a/src/shared/lib/three/animation/waveAnimation.ts
+++ b/src/shared/lib/three/animation/waveAnimation.ts
@@ -1,4 +1,4 @@
-import { BREAKPOINT_MOBILE_MAX } from '@shared/lib/breakpoint/useBreakpoint';
+import { isMobileViewport } from '@shared/lib/breakpoint/viewport';
 import type { Camera, Scene, WebGLRenderer } from 'three';
 
 import type { TubeData } from '../objects/type';
@@ -13,7 +13,7 @@ export function startWaveAnimation(
   const WAVE_FREQ = 0.4;
   const WAVE_SPEED = 0.3;
 
-  const isMobile = window.innerWidth <= BREAKPOINT_MOBILE_MAX;
+  const isMobile = isMobileViewport();
   const targetFPS = isMobile ? 30 : 60;
   const frameInterval = 1000 / targetFPS;
 

--- a/src/shared/lib/three/core/createRenderer.ts
+++ b/src/shared/lib/three/core/createRenderer.ts
@@ -1,10 +1,10 @@
-import { BREAKPOINT_MOBILE_MAX } from '@shared/lib/breakpoint/useBreakpoint';
+import { isMobileViewport } from '@shared/lib/breakpoint/viewport';
 import { WebGLRenderer } from 'three';
 
 const RENDER_SCALE = 0.5;
 
 export function createRenderer(canvas: HTMLCanvasElement) {
-  const isMobile = window.innerWidth <= BREAKPOINT_MOBILE_MAX;
+  const isMobile = isMobileViewport();
   const pixelRatio = Math.min(window.devicePixelRatio, isMobile ? 1.5 : 2);
 
   const renderer = new WebGLRenderer({

--- a/src/shared/lib/three/objects/createWaveTubes.ts
+++ b/src/shared/lib/three/objects/createWaveTubes.ts
@@ -1,4 +1,4 @@
-import { BREAKPOINT_MOBILE_MAX } from '@shared/lib/breakpoint/useBreakpoint';
+import { isMobileViewport } from '@shared/lib/breakpoint/viewport';
 import {
   type BufferAttribute,
   Color,
@@ -11,7 +11,7 @@ import {
 import type { TubeData } from './type';
 
 export function createWaveTubes(): { group: Group; tubes: TubeData[] } {
-  const isMobile = window.innerWidth <= BREAKPOINT_MOBILE_MAX;
+  const isMobile = isMobileViewport();
 
   const TUBE_COUNT = isMobile ? 20 : 30;
   const TUBE_RADIUS = 2;

--- a/src/widgets/award/model/responsive.ts
+++ b/src/widgets/award/model/responsive.ts
@@ -1,10 +1,10 @@
 import {
-  BREAKPOINT_MOBILE_MAX,
-  BREAKPOINT_TABLET_MAX,
-} from '@shared/lib/breakpoint/useBreakpoint';
+  isMobileViewport,
+  isTabletViewport,
+} from '@shared/lib/breakpoint/viewport';
 
 export function getItemsPerPage(): number {
-  if (window.innerWidth <= BREAKPOINT_MOBILE_MAX) return 4;
-  if (window.innerWidth <= BREAKPOINT_TABLET_MAX) return 6;
+  if (isMobileViewport()) return 4;
+  if (isTabletViewport()) return 6;
   return 10;
 }

--- a/src/widgets/hero/model/heroConfig.ts
+++ b/src/widgets/hero/model/heroConfig.ts
@@ -1,3 +1,0 @@
-export const showScrollArrow =
-  import.meta.env.MODE === 'production' ||
-  import.meta.env.VITE_SHOW_DOWN_ICON === 'true';


### PR DESCRIPTION
<!--
```
- PR이 승인되면 해당 브랜치 삭제하기
```
-->

# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #73
- #108

### viewport 판별 헬퍼 추출

- 작업 이유: Three.js 파일 3곳(`waveAnimation.ts`, `createRenderer.ts`, `createWaveTubes.ts`)과 `award/responsive.ts`에서 `window.innerWidth <= BREAKPOINT_MOBILE_MAX` 계산이 중복되어 있었음
- `shared/lib/breakpoint/viewport.ts`에 `isMobileViewport()` / `isTabletViewport()` 헬퍼 함수를 추출하여 중복 제거

### heroConfig 데드 코드 제거

- 작업 이유: `widgets/hero/model/heroConfig.ts`가 프로젝트 어디서도 import되지 않는 데드 코드였음
- `Home.tsx`가 `showScrollArrow` 로직을 직접 계산하고 있어 heroConfig는 불필요한 상태

### 핵심 변화

#### 변경 전

```ts
// 3개 파일에서 동일한 코드 반복
const isMobile = window.innerWidth <= BREAKPOINT_MOBILE_MAX;

// heroConfig.ts — 사용되지 않음
export const showScrollArrow =
  import.meta.env.MODE === 'production' ||
  import.meta.env.VITE_SHOW_DOWN_ICON === 'true';
```

#### 변경 후

```ts
// shared/lib/breakpoint/viewport.ts (신규)
export function isMobileViewport(): boolean {
  return window.innerWidth <= BREAKPOINT_MOBILE_MAX;
}

export function isTabletViewport(): boolean {
  return window.innerWidth <= BREAKPOINT_TABLET_MAX;
}

// 4곳에서 헬퍼 함수 사용
const isMobile = isMobileViewport();
```

# 📋 작업 내용

- `shared/lib/breakpoint/viewport.ts` 신규 생성 (`isMobileViewport`, `isTabletViewport`)
- `shared/lib/three/animation/waveAnimation.ts` — `isMobileViewport()` 적용
- `shared/lib/three/core/createRenderer.ts` — `isMobileViewport()` 적용
- `shared/lib/three/objects/createWaveTubes.ts` — `isMobileViewport()` 적용
- `widgets/award/model/responsive.ts` — `isMobileViewport()` / `isTabletViewport()` 적용
- `widgets/hero/model/heroConfig.ts` 삭제 (데드 코드)

# 📷 스크린 샷 (선택 사항)

동작 화면 첨부