### PR TITLE
🧹 clean: Footer CSS 중복 hr 규칙 제거

### DIFF
--- a/src/widgets/footer/styles/Footer.css
+++ b/src/widgets/footer/styles/Footer.css
@@ -175,10 +175,6 @@
     font-size: 1.82vw;
   }
 
-  .footer hr {
-    border-top: 1px solid rgb(var(--white-rgb) / var(--alpha-15));
-  }
-
   .footer__left,
   .footer__right {
     gap: 0.65vw;
@@ -234,10 +230,6 @@
 
   .footer__information button {
     font-size: clamp(9px, 2.67vw, 13px);
-  }
-
-  .footer hr {
-    border-top: 1px solid rgb(var(--white-rgb) / var(--alpha-15));
   }
 
   .footer__content {


### PR DESCRIPTION
<!--
```
- PR이 승인되면 해당 브랜치 삭제하기
```
-->

# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #124

### Footer CSS 중복 hr 규칙 제거

- 작업 이유: `.footer hr { border-top: ... }` 규칙이 base 스타일, `@media (max-width: 1024px)`, `@media (max-width: 767px)` 세 곳에서 완전히 동일한 값으로 선언되어 있었음
- 미디어쿼리 안의 2개 선언은 base 값을 덮어쓰지 않으므로 죽은 코드

### 핵심 변화

#### 변경 전

```css
/* base */
.footer hr {
  border-top: 1px solid rgb(var(--white-rgb) / var(--alpha-15));
}

/* @media (max-width: 1024px) — 동일, 불필요 */
.footer hr {
  border-top: 1px solid rgb(var(--white-rgb) / var(--alpha-15));
}

/* @media (max-width: 767px) — 동일, 불필요 */
.footer hr {
  border-top: 1px solid rgb(var(--white-rgb) / var(--alpha-15));
}
```

#### 변경 후

```css
/* base만 유지 */
.footer hr {
  border-top: 1px solid rgb(var(--white-rgb) / var(--alpha-15));
}
```

# 📋 작업 내용

- `src/widgets/footer/styles/Footer.css` — 미디어쿼리 내 중복 `.footer hr` 선언 2개 삭제 (8줄 제거)

# 📷 스크린 샷 (선택 사항)

동작 화면 첨부