### PR TITLE
🔨 refactor: Vision BEM 네이밍 수정 및 VisionTitle 애니메이션 내부화

### DIFF
--- a/src/widgets/vision/styles/VisionItem.css
+++ b/src/widgets/vision/styles/VisionItem.css
@@ -60,7 +60,7 @@
   -webkit-transform: scale(1.08);
 }
 
-.vision__content_text {
+.vision__content__text {
   display: flex;
   flex-direction: column;
   width: 45.43%;
@@ -126,7 +126,7 @@
     height: 55.34vw;
   }
 
-  .vision__content_text {
+  .vision__content__text {
     width: 33.59vw;
     gap: 2.6vw;
     padding: 0 3.91vw;
@@ -173,7 +173,7 @@
     height: clamp(190px, 54.4vw, 272px);
   }
 
-  .vision__content_text {
+  .vision__content__text {
     width: 100%;
     height: clamp(206px, 58.93vw, 295px);
     gap: clamp(14px, 4vw, 20px);

--- a/src/widgets/vision/ui/Vision.tsx
+++ b/src/widgets/vision/ui/Vision.tsx
@@ -3,18 +3,15 @@ import {
   VISION_IMAGE_MAP,
   VISION_SRCSET_MAP,
 } from '@entities/vision';
-import { useIntersectionAnimation } from '@shared/lib/useIntersectionAnimation';
 
 import '../styles/Vision.css';
 import { VisionItem } from './VisionItem';
 import { VisionTitle } from './VisionTitle';
 
 export function Vision() {
-  const titleRef = useIntersectionAnimation<HTMLElement>();
-
   return (
     <section id='vision' className='vision' aria-label='미래 비전'>
-      <VisionTitle ref={titleRef} />
+      <VisionTitle />
       <div className='vision__main'>
         {VISION_DATA.map((item, index) => (
           <VisionItem

--- a/src/widgets/vision/ui/VisionItem.tsx
+++ b/src/widgets/vision/ui/VisionItem.tsx
@@ -38,7 +38,7 @@ export function VisionItem({
           loading='lazy'
         />
       </div>
-      <div className='vision__content_text'>
+      <div className='vision__content__text'>
         <div className='vision__content__title'>
           <p className='vision__content__index'>VISION {index + 1}</p>
           <div className='vision__content__title__main'>

--- a/src/widgets/vision/ui/VisionTitle.test.tsx
+++ b/src/widgets/vision/ui/VisionTitle.test.tsx
@@ -1,31 +1,39 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { VisionTitle } from './VisionTitle';
 
-const nullRef = { current: null };
+beforeEach(() => {
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      observe = vi.fn();
+      disconnect = vi.fn();
+    },
+  );
+});
 
 describe('VisionTitle', () => {
   describe('vision__title 콘텐츠', () => {
     it('"CONCEPT" 텍스트가 렌더링된다', () => {
-      render(<VisionTitle ref={nullRef} />);
+      render(<VisionTitle />);
       expect(screen.getByText('CONCEPT')).toBeInTheDocument();
     });
 
     it('"미래를 향한" h2가 렌더링된다', () => {
-      render(<VisionTitle ref={nullRef} />);
+      render(<VisionTitle />);
       expect(screen.getByText('미래를 향한')).toBeInTheDocument();
     });
   });
 
   describe('시맨틱 구조', () => {
     it('vision__title 클래스가 존재한다', () => {
-      const { container } = render(<VisionTitle ref={nullRef} />);
+      const { container } = render(<VisionTitle />);
       expect(container.querySelector('.vision__title')).toBeInTheDocument();
     });
 
     it('hr 구분선이 렌더링된다', () => {
-      const { container } = render(<VisionTitle ref={nullRef} />);
+      const { container } = render(<VisionTitle />);
       expect(container.querySelector('hr')).toBeInTheDocument();
     });
   });

--- a/src/widgets/vision/ui/VisionTitle.tsx
+++ b/src/widgets/vision/ui/VisionTitle.tsx
@@ -1,12 +1,11 @@
+import { useIntersectionAnimation } from '@shared/lib/useIntersectionAnimation';
 import { SectionTitle } from '@shared/ui/SectionTitle';
 
 import '../styles/VisionTitle.css';
 
-export function VisionTitle({
-  ref,
-}: {
-  ref?: React.RefObject<HTMLElement | null>;
-}) {
+export function VisionTitle() {
+  const ref = useIntersectionAnimation<HTMLElement>();
+
   return (
     <SectionTitle
       ref={ref}


### PR DESCRIPTION
<!--
```
- PR이 승인되면 해당 브랜치 삭제하기
```
-->

# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #122

### BEM 네이밍 일관성 수정

- 작업 이유: `VisionItem` 내 `vision__content_text`(싱글 언더스코어)가 같은 블록의 다른 요소들(`vision__content__image`, `vision__content__title` 등 더블 언더스코어)과 불일치
- `vision__content_text` → `vision__content__text`로 통일

### VisionTitle 애니메이션 내부화

- 작업 이유: `VisionItem`은 `useIntersectionAnimation`을 자체적으로 관리하지만 `VisionTitle`만 외부(`Vision.tsx`)에서 ref를 받는 구조였음 — 동일 도메인 내 컴포넌트 간 비대칭
- `VisionTitle`이 자체적으로 `useIntersectionAnimation`을 호출하도록 변경하여 `VisionItem`과 동일한 패턴으로 통일

### 핵심 변화

#### 변경 전

```tsx
// Vision.tsx — 타이틀 애니메이션을 외부에서 관리
const titleRef = useIntersectionAnimation<HTMLElement>();
<VisionTitle ref={titleRef} />

// VisionTitle.tsx — ref를 prop으로 받음
export function VisionTitle({ ref }: { ref?: React.RefObject<HTMLElement | null> }) { ... }
```

#### 변경 후

```tsx
// Vision.tsx — 애니메이션 의존성 없음
<VisionTitle />

// VisionTitle.tsx — 자체적으로 애니메이션 관리 (VisionItem과 동일 패턴)
export function VisionTitle() {
  const ref = useIntersectionAnimation<HTMLElement>();
  ...
}
```

# 📋 작업 내용

- `VisionItem.tsx` — `vision__content_text` → `vision__content__text`
- `VisionItem.css` — 동일 클래스명 3곳 일괄 수정
- `VisionTitle.tsx` — ref prop 제거, `useIntersectionAnimation` 내부 호출
- `Vision.tsx` — `titleRef` 및 `useIntersectionAnimation` import 제거
- `VisionTitle.test.tsx` — `IntersectionObserver` mock 추가, `nullRef` 제거

# 📷 스크린 샷 (선택 사항)

동작 화면 첨부