### PR TITLE
🧹 clean: Patent CSS 중복 hr 규칙 제거

### DIFF
--- a/src/widgets/patent/styles/ExpireContent.css
+++ b/src/widgets/patent/styles/ExpireContent.css
@@ -133,10 +133,6 @@
     font-size: 2.6vw;
   }
 
-  .patent__expiration__title hr {
-    border-top: 1px solid var(--patent-divider);
-  }
-
   .patent__expiration__content {
     display: flex;
     flex-direction: column;
@@ -160,10 +156,6 @@
 
   .patent__expiration__item__content span:last-child {
     font-size: 1.95vw;
-  }
-
-  .patent__expiration__item hr {
-    border-top: 1px solid var(--patent-item-divider);
   }
 
   .patent__expiration__serial {
@@ -193,10 +185,6 @@
     font-size: clamp(13px, 3.73vw, 19px);
   }
 
-  .patent__expiration__title hr {
-    border-top: 1px solid var(--patent-divider);
-  }
-
   .patent__expiration__content {
     gap: clamp(23px, 6.67vw, 33px);
   }
@@ -215,10 +203,6 @@
 
   .patent__expiration__item__content span:last-child {
     font-size: clamp(11px, 3.2vw, 16px);
-  }
-
-  .patent__expiration__item hr {
-    border-top: 1px solid var(--patent-item-divider);
   }
 
   .patent__expiration__serial {

--- a/src/widgets/patent/styles/ValidContent.css
+++ b/src/widgets/patent/styles/ValidContent.css
@@ -84,10 +84,6 @@
     font-size: 2.86vw;
   }
 
-  .patent__content__title hr {
-    border-top: 1px solid var(--patent-divider);
-  }
-
   .patent__content__item__list {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -118,10 +114,6 @@
 
   .patent__content__title__text h3 {
     font-size: clamp(15px, 4.27vw, 21px);
-  }
-
-  .patent__content__title hr {
-    border-top: 1px solid var(--patent-divider);
   }
 
   .patent__content__item__list {


### PR DESCRIPTION
<!--
```
- PR이 승인되면 해당 브랜치 삭제하기
```
-->

# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #121

### Patent CSS 중복 hr 규칙 제거

- 작업 이유: `border-top` 값이 base 스타일과 동일함에도 `@media (max-width: 1024px)`, `@media (max-width: 767px)` 블록 내에 그대로 복붙된 규칙 6개가 존재
- Footer에서 발견된 것과 완전히 동일한 패턴으로, 해당 미디어쿼리 선언들은 base 값을 덮어쓰지 않으므로 죽은 코드

### 핵심 변화

#### 변경 전

```css
/* base */
.patent__content__title hr {
  border: none;
  border-top: 1px solid var(--patent-divider);
}

/* @media (max-width: 1024px) — 동일, 불필요 */
.patent__content__title hr {
  border-top: 1px solid var(--patent-divider);
}

/* @media (max-width: 767px) — 동일, 불필요 */
.patent__content__title hr {
  border-top: 1px solid var(--patent-divider);
}
```

#### 변경 후

```css
/* base만 유지 */
.patent__content__title hr {
  border: none;
  border-top: 1px solid var(--patent-divider);
}
```

# 📋 작업 내용

**`ValidContent.css`** — 중복 규칙 2개 삭제
- `.patent__content__title hr` (1024px, 767px 미디어쿼리)

**`ExpireContent.css`** — 중복 규칙 4개 삭제
- `.patent__expiration__title hr` (1024px, 767px 미디어쿼리)
- `.patent__expiration__item hr` (1024px, 767px 미디어쿼리)

# 📷 스크린 샷 (선택 사항)

동작 화면 첨부