### PR TITLE
🔨 refactor: Map 도메인 최종 리팩토링

### DIFF
--- a/src/widgets/map/ui/MapCard.test.tsx
+++ b/src/widgets/map/ui/MapCard.test.tsx
@@ -1,4 +1,4 @@
-import { TRANSPORT_ITEMS } from '@entities/map/model/transportInfo';
+import { TRANSPORT_ITEMS } from '@entities/map';
 import { COMPANY } from '@shared/constant';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';

--- a/src/widgets/map/ui/MapCard.tsx
+++ b/src/widgets/map/ui/MapCard.tsx
@@ -1,6 +1,6 @@
 import { FiPhoneCall } from 'react-icons/fi';
 
-import { TRANSPORT_ITEMS } from '@entities/map/model/transportInfo';
+import { TRANSPORT_ITEMS } from '@entities/map';
 import { COMPANY } from '@shared/constant';
 
 import '../styles/MapCard.css';

--- a/src/widgets/map/ui/MapInfoCard.test.tsx
+++ b/src/widgets/map/ui/MapInfoCard.test.tsx
@@ -4,9 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { MapInfoCard } from './MapInfoCard';
 
-vi.mock('@assets/induel-icon.svg?raw', () => ({
-  default: '<svg viewBox="0 0 649 748"><g /></svg>',
-}));
+vi.mock('@assets/induel-icon.svg', () => ({ default: 'induel-icon.svg' }));
 
 describe('MapInfoCard', () => {
   it('회사 한글 이름이 렌더링된다', () => {

--- a/src/widgets/map/ui/MapInfoCard.tsx
+++ b/src/widgets/map/ui/MapInfoCard.tsx
@@ -1,5 +1,7 @@
 import { COMPANY } from '@shared/constant';
 
+import induelIcon from '@assets/induel-icon.svg';
+
 import '../styles/mapInfoCard.css';
 
 export function MapInfoCard() {
@@ -7,25 +9,12 @@ export function MapInfoCard() {
     <div className='map__info'>
       <div className='map__info__card'>
         <div className='map__info__header'>
-          <svg
+          <img
+            src={induelIcon}
             className='map__info__logo'
-            viewBox='0 0 649 748'
-            fill='none'
-            xmlns='http://www.w3.org/2000/svg'
-          >
-            <path
-              d='M275.115 -6.10352e-05H197.814V157.373H275.115C394.499 157.373 491.627 254.501 491.627 373.885C491.627 493.269 394.499 590.397 275.115 590.397H157.37V747.764H275.115C481.595 747.764 649 580.372 649 373.885C649 167.392 481.595 -6.10352e-05 275.115 -6.10352e-05Z'
-              fill='#808285'
-            />
-            <path
-              d='M0 197.811V609.671V747.764H157.373V609.671V197.811H0Z'
-              fill='#333132'
-            />
-            <path
-              d='M0 -0.000259399H157.373V157.373H0V-0.000259399Z'
-              fill='#BF1E2D'
-            />
-          </svg>
+            alt=''
+            aria-hidden='true'
+          />
           <div>
             <p className='map__info__name'>{COMPANY.NAME_KO}</p>
             <p className='map__info__subtitle'>{COMPANY.NAME_EN_FULL}</p>

--- a/src/widgets/map/ui/MapMarker.test.tsx
+++ b/src/widgets/map/ui/MapMarker.test.tsx
@@ -3,9 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { MapMarker } from './MapMarker';
 
-vi.mock('@assets/induel-icon.svg?raw', () => ({
-  default: '<svg viewBox="0 0 649 748"><g /></svg>',
-}));
+vi.mock('@assets/induel-icon.svg', () => ({ default: 'induel-icon.svg' }));
 
 describe('MapMarker', () => {
   it('SVG 루트 요소가 map__marker 클래스로 렌더링된다', () => {

--- a/src/widgets/map/ui/MapMarker.tsx
+++ b/src/widgets/map/ui/MapMarker.tsx
@@ -1,3 +1,5 @@
+import induelIcon from '@assets/induel-icon.svg';
+
 import '../styles/mapMarker.css';
 
 export function MapMarker() {
@@ -29,27 +31,14 @@ export function MapMarker() {
         d='M22 3C14.5 3 8 7.5 5.5 14C9 9 15 6 22 6C29 6 35 9 38.5 14C36 7.5 29.5 3 22 3Z'
       />
       <circle className='map__marker__circle' cx='22' cy='21' r='14' />
-      <svg
+      <image
         x='15'
         y='12'
         width='16'
         height='18'
-        viewBox='0 0 649 748'
+        href={induelIcon}
         preserveAspectRatio='xMidYMid meet'
-      >
-        <path
-          d='M275.115 -6.10352e-05H197.814V157.373H275.115C394.499 157.373 491.627 254.501 491.627 373.885C491.627 493.269 394.499 590.397 275.115 590.397H157.37V747.764H275.115C481.595 747.764 649 580.372 649 373.885C649 167.392 481.595 -6.10352e-05 275.115 -6.10352e-05Z'
-          fill='#808285'
-        />
-        <path
-          d='M0 197.811V609.671V747.764H157.373V609.671V197.811H0Z'
-          fill='#333132'
-        />
-        <path
-          d='M0 -0.000259399H157.373V157.373H0V-0.000259399Z'
-          fill='#BF1E2D'
-        />
-      </svg>
+      />
     </svg>
   );
 }


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #123

### FSD public API 위반 수정

`MapCard.tsx`가 `@entities/map`의 public API(index)를 거치지 않고 내부 경로를 직접 import하고 있었습니다.

```ts
// 변경 전
import { TRANSPORT_ITEMS } from '@entities/map/model/transportInfo';

// 변경 후
import { TRANSPORT_ITEMS } from '@entities/map';
```

전체 코드베이스를 grep한 결과 이 패턴은 Map 도메인에만 존재했으며, 다른 도메인(Award, History, Patent 등)은 모두 public API를 올바르게 사용하고 있었습니다.

### 회사 로고 SVG 중복 제거

`MapInfoCard.tsx`와 `MapMarker.tsx` 두 곳에 동일한 SVG path 데이터 3개가 하드코딩 중복되어 있었습니다. `shared/assets/induel-icon.svg`가 이미 존재하므로 이를 import해 사용하도록 변경했습니다.

### 핵심 변화

#### 변경 전

```tsx
// MapInfoCard.tsx — SVG 경로 하드코딩
<svg className='map__info__logo' viewBox='0 0 649 748' fill='none' xmlns='...'>
  <path d='M275.115 ...' fill='#808285' />
  <path d='M0 197.811...' fill='#333132' />
  <path d='M0 -0.000259399...' fill='#BF1E2D' />
</svg>

// MapMarker.tsx — 동일 경로 중복
<svg x='15' y='12' width='16' height='18' viewBox='0 0 649 748' ...>
  <path d='M275.115 ...' fill='#808285' />
  ...
</svg>
```

#### 변경 후

```tsx
// MapInfoCard.tsx
import induelIcon from '@assets/induel-icon.svg';
<img src={induelIcon} className='map__info__logo' alt='' aria-hidden='true' />

// MapMarker.tsx
import induelIcon from '@assets/induel-icon.svg';
<image x='15' y='12' width='16' height='18' href={induelIcon} preserveAspectRatio='xMidYMid meet' />
```

# 📋 작업 내용

- `MapCard.tsx` / `MapCard.test.tsx` — `@entities/map` public API 사용으로 수정 (FSD 규칙)
- `MapInfoCard.tsx` — inline SVG 제거, `induel-icon.svg` import로 교체
- `MapMarker.tsx` — inline `<svg>` 제거, SVG `<image href>` 요소로 교체
- `MapInfoCard.test.tsx` / `MapMarker.test.tsx` — 올바른 SVG mock 추가 (`@assets/induel-icon.svg`)