### PR TITLE
📝 docs: Vision 도메인 Storybook 작성

### DIFF
--- a/src/widgets/vision/ui/Vision.stories.tsx
+++ b/src/widgets/vision/ui/Vision.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Vision } from './Vision';
+
+const meta = {
+  title: 'Widgets/Vision',
+  component: Vision,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Page 2–4에 위치하는 Vision 위젯. Param · Sculpt · Invest 세 개의 비전 아이템을 교차 레이아웃(이미지 좌우 반전)으로 렌더링합니다. 각 아이템은 IntersectionObserver 기반 진입 애니메이션을 포함합니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof Vision>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Vision 뷰포트',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '전체 Vision 섹션. 상단 타이틀과 세 개의 비전 아이템(Param → Sculpt → Invest)이 순서대로 나열됩니다.',
+      },
+    },
+  },
+};

--- a/src/widgets/vision/ui/VisionItem.stories.tsx
+++ b/src/widgets/vision/ui/VisionItem.stories.tsx
@@ -1,0 +1,101 @@
+import { VISION_DATA, VISION_IMAGE_MAP } from '@entities/vision';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { VisionItem } from './VisionItem';
+
+const [param, sculpt, invest] = VISION_DATA;
+
+const meta = {
+  title: 'Widgets/Vision/VisionItem',
+  component: VisionItem,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Vision 섹션의 개별 아이템 컴포넌트. index가 홀수이면 이미지와 텍스트 순서가 반전되며 어두운 배경 테마가 적용됩니다. IntersectionObserver가 뷰포트 진입을 감지해 페이드-업 애니메이션을 트리거합니다.',
+      },
+    },
+  },
+  argTypes: {
+    index: {
+      control: { type: 'number' },
+      description: '아이템 순서 (짝수: 기본 / 홀수: reverse 레이아웃)',
+    },
+    keyword: {
+      control: 'text',
+      description: '대형 영문 키워드 (h3)',
+    },
+    title: {
+      control: 'text',
+      description: '한글 부제목 (h4)',
+    },
+    description: {
+      control: 'text',
+      description: '설명 본문',
+    },
+    image: {
+      control: false,
+      description: '이미지 URL (VISION_IMAGE_MAP 에서 resolve된 값)',
+    },
+  },
+} satisfies Meta<typeof VisionItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Param: Story = {
+  name: 'VISION 1 — Param (기본)',
+  args: {
+    index: 0,
+    keyword: param.keyword,
+    title: param.title,
+    description: param.description,
+    image: VISION_IMAGE_MAP[param.image],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '짝수 index(0). 이미지가 왼쪽, 텍스트가 오른쪽에 배치되며 크림 배경이 적용됩니다.',
+      },
+    },
+  },
+};
+
+export const Sculpt: Story = {
+  name: 'VISION 2 — Sculpt (reverse)',
+  args: {
+    index: 1,
+    keyword: sculpt.keyword,
+    title: sculpt.title,
+    description: sculpt.description,
+    image: VISION_IMAGE_MAP[sculpt.image],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '홀수 index(1). 이미지가 오른쪽, 텍스트가 왼쪽으로 반전되며 짙은 브라운 배경과 골드 키워드 색상이 적용됩니다.',
+      },
+    },
+  },
+};
+
+export const Invest: Story = {
+  name: 'VISION 3 — Invest (기본)',
+  args: {
+    index: 2,
+    keyword: invest.keyword,
+    title: invest.title,
+    description: invest.description,
+    image: VISION_IMAGE_MAP[invest.image],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '짝수 index(2). Param과 동일한 기본 레이아웃 · 배경 테마.',
+      },
+    },
+  },
+};

--- a/src/widgets/vision/ui/VisionTitle.stories.tsx
+++ b/src/widgets/vision/ui/VisionTitle.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { VisionTitle } from './VisionTitle';
+
+const meta = {
+  title: 'Widgets/Vision/VisionTitle',
+  component: VisionTitle,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Vision 섹션 상단 타이틀. 영문 서브타이틀 "CONCEPT"과 한글 메인 타이틀 "미래를 향한"을 SectionTitle 공유 컴포넌트로 렌더링합니다. IntersectionObserver 기반 페이드-업 애니메이션이 포함됩니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof VisionTitle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '기본',
+  parameters: {
+    docs: {
+      description: {
+        story: '뷰포트 진입 시 is-visible 클래스가 부착되어 나타나는 타이틀.',
+      },
+    },
+  },
+};


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- #48

### Vision Storybook 작성

- Vision 위젯 도메인에 Storybook 스토리가 없어 문서화 및 시각적 검증이 불가능했음
- 컴포넌트별로 스토리를 분리하여 독립적인 렌더링 확인이 가능하도록 구성

### 핵심 변화

#### 변경 전

Vision 도메인에 Storybook 스토리 파일 없음

#### 변경 후

- `Vision.stories.tsx` — 전체 섹션 (Desktop · Tablet · Mobile 뷰포트 스토리)
- `VisionItem.stories.tsx` — 개별 아이템 컴포넌트 (Param · Sculpt · Invest + 모바일), `argTypes`로 Controls 패널에서 텍스트 실시간 편집 가능
- `VisionTitle.stories.tsx` — 섹션 타이틀 컴포넌트

# 📋 작업 내용

- `src/widgets/vision/ui/` 하위에 `*.stories.tsx` 파일 3개 추가
- 기존 프로젝트 스토리 패턴(`satisfies Meta<typeof X>`, `layout: fullscreen/centered`) 통일
- `VisionItem` index 짝/홀에 따른 레이아웃·테마 반전(reverse)을 별도 스토리로 분리
- `.storybook/preview.ts`에 정의된 Desktop · Tablet · Mobile 뷰포트 활용

# 📷 스크린 샷 (선택 사항)

동작 화면 첨부