### PR TITLE
📝 docs: Footer Storybook 명세 구체화

### DIFF
--- a/src/widgets/footer/ui/Footer.stories.tsx
+++ b/src/widgets/footer/ui/Footer.stories.tsx
@@ -18,8 +18,19 @@ const meta = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component:
-          'Page 7 하단에 위치하는 Footer 위젯. 회사 로고, 회사명, 개인정보처리방침 링크, 사업자 정보, 연락처, 저작권 표기를 포함합니다.',
+        component: [
+          'Page 7 하단에 위치하는 Footer 위젯.',
+          '',
+          '**구성 영역**',
+          '- 좌측 상단: 회사 로고 아이콘 + 한글/영문 회사명',
+          '- 우측 상단: 개인정보처리방침 버튼 (`/privacy_policy` 라우트로 이동)',
+          '- 구분선(hr)',
+          '- 좌측 하단: 대표이사명 · 사업자등록번호 · 주소',
+          '- 우측 하단: TEL · FAX · EMAIL',
+          '- 하단: 저작권 표기 (설립 연도 ~ 현재 연도)',
+          '',
+          '`useNavigate` 의존성이 있어 MemoryRouter 데코레이터가 적용됩니다.',
+        ].join('\n'),
       },
     },
   },
@@ -33,7 +44,8 @@ export const Default: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Footer 레이아웃.',
+        story:
+          '실제 서비스와 동일한 Footer 레이아웃. 회사 정보(대표이사, 사업자등록번호, 주소, 연락처)와 저작권 표기가 렌더링됩니다.',
       },
     },
   },


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- #48

### Footer Storybook 명세 구체화

- 기존 Footer.stories.tsx의 컴포넌트/스토리 설명이 지나치게 간소하여 문서 가치가 낮았음
- 구성 영역 6개를 명시하고, MemoryRouter 데코레이터 적용 이유를 기술하도록 개선

### 핵심 변화

#### 변경 전

```
component: 'Page 7 하단에 위치하는 Footer 위젯. 회사 로고, 회사명, 개인정보처리방침 링크, 사업자 정보, 연락처, 저작권 표기를 포함합니다.'
story: 'Footer 레이아웃.'
```

#### 변경 후

- component description: 좌상단(로고·회사명) · 우상단(개인정보처리방침 버튼) · hr · 좌하단(대표이사·사업자등록번호·주소) · 우하단(TEL·FAX·EMAIL) · 저작권 영역을 항목별로 명세, MemoryRouter 데코레이터 이유 추가
- story description: 렌더링되는 데이터 항목을 구체적으로 기술

# 📋 작업 내용

- `src/widgets/footer/ui/Footer.stories.tsx` 문서 설명 보강

# 📷 스크린 샷 (선택 사항)

동작 화면 첨부