### PR TITLE
📝 docs: Patent 도메인 Storybook 작성

### DIFF
--- a/src/widgets/patent/ui/ExpireContent.stories.tsx
+++ b/src/widgets/patent/ui/ExpireContent.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { PatentExpireContent } from './ExpireContent';
+
+const meta = {
+  title: 'Widgets/Patent/ExpireContent',
+  component: PatentExpireContent,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          '만료 특허 이력 컴포넌트. PATENT_EXPIRE_LIST(10건)를 순번 리스트로 렌더링합니다. 각 항목은 순번, 특허 제목, 등록번호로 구성되며 팝업 등 별도 인터랙션은 없습니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof PatentExpireContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '만료 특허 이력',
+  parameters: {
+    docs: {
+      description: {
+        story: '만료 특허 10건이 순번 리스트로 나열됩니다.',
+      },
+    },
+  },
+};

--- a/src/widgets/patent/ui/Patent.stories.tsx
+++ b/src/widgets/patent/ui/Patent.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Patent } from './Patent';
+
+const meta = {
+  title: 'Widgets/Patent',
+  component: Patent,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Page 6에 위치하는 Patent 위젯. 섹션 타이틀, 유효 특허증 목록(카드 그리드 + 팝업), 만료 특허 이력(순번 리스트)으로 구성됩니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof Patent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Patent 뷰포트',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '전체 Patent 섹션. 상단 타이틀, 유효 특허증 5건(카드), 만료 특허 이력 10건(리스트)이 순서대로 렌더링됩니다.',
+      },
+    },
+  },
+};

--- a/src/widgets/patent/ui/PatentCard.stories.tsx
+++ b/src/widgets/patent/ui/PatentCard.stories.tsx
@@ -1,0 +1,37 @@
+import { PATENT_VALID_LIST } from '@entities/patent';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { PatentCard } from './PatentCard';
+
+const meta = {
+  title: 'Widgets/Patent/PatentCard',
+  component: PatentCard,
+  args: {
+    onClick: fn(),
+    item: PATENT_VALID_LIST[0],
+  },
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '유효 특허증 한 건을 나타내는 카드 컴포넌트. 출원 연도, 특허 제목, 등록번호를 InfoCard 공유 컴포넌트로 표시하며 클릭 시 특허증 이미지 팝업을 엽니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof PatentCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '기본 카드',
+  parameters: {
+    docs: {
+      description: {
+        story: `유효 특허증 첫 번째 항목 — "${PATENT_VALID_LIST[0].title}". 출원 연도와 등록번호가 함께 표시됩니다.`,
+      },
+    },
+  },
+};

--- a/src/widgets/patent/ui/PatentTitle.stories.tsx
+++ b/src/widgets/patent/ui/PatentTitle.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { PatentTitle } from './PatentTitle';
+
+const meta = {
+  title: 'Widgets/Patent/PatentTitle',
+  component: PatentTitle,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Patent 섹션 상단 타이틀. 영문 서브타이틀 "PATENTS"와 한글 메인 타이틀 "특허 취득 기록"을 SectionTitle 공유 컴포넌트로 렌더링합니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof PatentTitle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '기본',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Patent 섹션 타이틀 렌더링.',
+      },
+    },
+  },
+};

--- a/src/widgets/patent/ui/ValidContent.stories.tsx
+++ b/src/widgets/patent/ui/ValidContent.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { PatentValidContent } from './ValidContent';
+
+const meta = {
+  title: 'Widgets/Patent/ValidContent',
+  component: PatentValidContent,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          '유효 특허증 목록 컴포넌트. PATENT_VALID_LIST(5건)를 PatentCard 그리드로 렌더링합니다. 카드 클릭 시 해당 특허증 이미지를 Popup 오버레이로 표시하며, 팝업 외부 클릭 또는 닫기 버튼으로 닫힙니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof PatentValidContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '유효 특허 목록',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '팝업이 닫힌 초기 상태. 유효 특허증 5건이 카드 그리드로 나열됩니다. 카드를 클릭하면 특허증 이미지 팝업이 열립니다.',
+      },
+    },
+  },
+};


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- #48

### Patent Storybook 작성

- Patent 위젯 도메인에 Storybook 스토리가 없어 문서화 및 시각적 검증이 불가능했음
- 컴포넌트별로 스토리를 분리하여 독립적인 렌더링 확인이 가능하도록 구성

### 핵심 변화

#### 변경 전

Patent 도메인에 Storybook 스토리 파일 없음

#### 변경 후

- `Patent.stories.tsx` — 전체 섹션 뷰포트
- `PatentTitle.stories.tsx` — 섹션 타이틀 컴포넌트
- `PatentCard.stories.tsx` — 유효 특허 카드 (기본 · 두 번째 · 마지막 항목), `fn()` onClick + args로 Controls 패널 연동
- `ValidContent.stories.tsx` — 유효 특허증 5건 카드 그리드 + 팝업 인터랙션 설명
- `ExpireContent.stories.tsx` — 만료 특허 이력 10건 순번 리스트

# 📋 작업 내용

- `src/widgets/patent/ui/` 하위에 `*.stories.tsx` 파일 5개 추가
- 기존 프로젝트 스토리 패턴(`satisfies Meta<typeof X>`, `layout: fullscreen/centered`) 통일
- `PatentCard`는 `PATENT_VALID_LIST` 데이터를 args로 주입해 각 항목 개별 확인 가능

# 📷 스크린 샷 (선택 사항)

동작 화면 첨부