### PR TITLE
🧹 clean: award storybook 리팩토링

### DIFF
--- a/src/features/award/ui/YearCategory.stories.tsx
+++ b/src/features/award/ui/YearCategory.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
 
 import { YEAR_LIST } from '../model/constant';
 import { YearCategory } from './YearCategory';
@@ -9,7 +10,7 @@ const meta = {
   args: {
     yearList: YEAR_LIST,
     activeYear: '전체',
-    onYearChange: () => {},
+    onYearChange: fn(),
   },
   parameters: {
     layout: 'centered',

--- a/src/widgets/award/ui/Viewport.stories.tsx
+++ b/src/widgets/award/ui/Viewport.stories.tsx
@@ -45,7 +45,7 @@ export const Default: Story = {
   },
 };
 
-export const Tablet = {
+export const Tablet: Story = {
   name: '(3×2, 6개/페이지)',
   globals: {
     viewport: { value: 'tablet' },
@@ -53,7 +53,7 @@ export const Tablet = {
   args: { itemsPerPage: 6, totalPages: Math.ceil(AWARD_LIST.length / 6) },
 };
 
-export const Mobile = {
+export const Mobile: Story = {
   name: '(2×2, 4개/페이지)',
   globals: {
     viewport: { value: 'mobile' },


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- #48

### Award Storybook 일관성 수정

- `YearCategory.stories.tsx`의 `onYearChange`가 `() => {}`로 되어 있어 다른 모든 콜백(`fn()`)과 불일치. Actions 패널에서 이벤트가 잡히지 않는 문제 수정.
- `Viewport.stories.tsx`의 `Tablet`, `Mobile` 스토리에 타입 어노테이션이 누락되어 있어 `Default`와 불일치. `Story` 타입 추가.

### 핵심 변화

#### 변경 전

- `YearCategory.stories.tsx`: `onYearChange: () => {}`
- `Viewport.stories.tsx`: `export const Tablet = { ... }`, `export const Mobile = { ... }`

#### 변경 후

- `YearCategory.stories.tsx`: `onYearChange: fn()`
- `Viewport.stories.tsx`: `export const Tablet: Story = { ... }`, `export const Mobile: Story = { ... }`

# 📋 작업 내용

- `YearCategory.stories.tsx`: `onYearChange` 콜백을 `fn()`으로 교체 및 `storybook/test` import 추가
- `Viewport.stories.tsx`: `Tablet`, `Mobile` 스토리에 `: Story` 타입 어노테이션 추가