### PR TITLE
🧹 clean: hero storybook 타입 정리

### DIFF
--- a/src/widgets/hero/ui/Hero.stories.tsx
+++ b/src/widgets/hero/ui/Hero.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Hero } from './Hero';
 
-const meta: Meta<typeof Hero> = {
+const meta = {
   title: 'Widgets/Hero',
   component: Hero,
   parameters: {
@@ -14,11 +14,11 @@ const meta: Meta<typeof Hero> = {
       },
     },
   },
-};
+} satisfies Meta<typeof Hero>;
 
 export default meta;
 
-type Story = StoryObj<typeof Hero>;
+type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   name: 'Prod Hero 뷰포트',


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- #48

### Hero Storybook 타입 선언 통일

- `Hero.stories.tsx`만 `const meta: Meta<typeof Hero> = { ... }` / `StoryObj<typeof Hero>` 구문을 사용하고 있어 프로젝트 내 나머지 모든 스토리의 패턴과 불일치

### 핵심 변화

#### 변경 전

```ts
const meta: Meta<typeof Hero> = { ... };
type Story = StoryObj<typeof Hero>;
```

#### 변경 후

```ts
const meta = { ... } satisfies Meta<typeof Hero>;
type Story = StoryObj<typeof meta>;
```

# 📋 작업 내용

- `Hero.stories.tsx`: meta 선언을 `satisfies Meta<typeof Hero>` + `StoryObj<typeof meta>` 패턴으로 통일