### PR TITLE
🔨 refactor: Patent Popup 분리, 문자열 객체 치환

### DIFF
--- a/src/features/history/index.ts
+++ b/src/features/history/index.ts
@@ -1,6 +1,11 @@
 export { useBookNavigation } from './model/useBookNavigation';
 export { useBookCoverState } from './model/useBookCoverState';
-export { INDEX_LIST, PAGE_SIDE, RAPID_FLIP_DURATION } from './model/constants';
+export {
+  INDEX_LIST,
+  PAGE_SIDE,
+  RAPID_FLIP_DURATION,
+  BOOK_STATE,
+} from './model/constants';
 export { getArtworkIndex, preloadContentImages } from './model/helpers';
 export { MILESTONES_YEAR_RANGES_BY_BREAKPOINT } from './model/pageRegistry';
 export type {

--- a/src/features/history/model/constants.ts
+++ b/src/features/history/model/constants.ts
@@ -13,3 +13,13 @@ export const FLIP_DURATION = 800;
 export const RAPID_FLIP_DURATION = 300;
 export const PASS_THROUGH_FLIP_DURATION = 150;
 export const MAX_SOURCE_PAGE_FLIPS = 3;
+
+export const BOOK_STATE = {
+  COVER_FRONT: 'cover-front', // 앞 표지 상태 (기본 닫힌 상태, 정면)
+  OPENING_FRONT: 'opening-front', // 앞 표지 → 펼쳐지는 중 (forward flip 애니메이션)
+  OPEN: 'open', // 책이 완전히 펼쳐진 상태 (좌/우 페이지 모두 노출)
+  CLOSING_FRONT: 'closing-front', // 펼쳐진 상태 → 앞 표지로 닫히는 중 (reverse flip)
+  COVER_BACK: 'cover-back', // 뒤 표지 상태 (뒤쪽 기준 닫힌 상태)
+  OPENING_BACK: 'opening-back', // 뒤 표지 → 펼쳐지는 중 (backward flip 애니메이션)
+  CLOSING_BACK: 'closing-back', // 펼쳐진 상태 → 뒤 표지로 닫히는 중 (reverse to back cover)
+};

--- a/src/features/history/model/types.ts
+++ b/src/features/history/model/types.ts
@@ -1,3 +1,5 @@
+import type { BOOK_STATE } from './constants';
+
 export type PageSide = 'left' | 'right';
 
 export type IndexItem = 'List' | 'Content' | 'Timeline' | 'Milestones';
@@ -10,11 +12,4 @@ export type NavigationStep = {
   duration?: number;
 };
 
-export type BookState =
-  | 'cover-front' // 앞표지만 보임 (중앙 위치)
-  | 'opening-front' // 앞표지 → 첫 페이지 열리는 중 (flip forward)
-  | 'open' // 책 펼쳐진 상태
-  | 'closing-front' // 첫 페이지 → 앞표지로 닫히는 중 (flip backward)
-  | 'cover-back' // 뒤표지만 보임 (중앙 위치)
-  | 'opening-back' // 뒤표지 → 마지막 페이지 열리는 중 (flip backward)
-  | 'closing-back'; // 마지막 페이지 → 뒤표지로 닫히는 중 (flip forward)
+export type BookState = (typeof BOOK_STATE)[keyof typeof BOOK_STATE];

--- a/src/features/history/model/useBookCoverState.ts
+++ b/src/features/history/model/useBookCoverState.ts
@@ -1,40 +1,41 @@
 import { useState } from 'react';
 
-import type { BookState } from './types';
+import { BOOK_STATE } from './constants';
+import { type BookState } from './types';
 
 export function useBookCoverState() {
-  const [bookState, setBookState] = useState<BookState>('cover-front');
+  const [bookState, setBookState] = useState<BookState>(BOOK_STATE.COVER_FRONT);
 
   function openingFront() {
-    if (bookState !== 'cover-front') return;
-    setBookState('opening-front');
+    if (bookState !== BOOK_STATE.COVER_FRONT) return;
+    setBookState(BOOK_STATE.OPENING_FRONT);
   }
 
   function onOpened() {
-    setBookState('open');
+    setBookState(BOOK_STATE.OPEN);
   }
 
   function closingFront() {
-    if (bookState !== 'open') return;
-    setBookState('closing-front');
+    if (bookState !== BOOK_STATE.OPEN) return;
+    setBookState(BOOK_STATE.CLOSING_FRONT);
   }
 
   function onFrontClosed() {
-    setBookState('cover-front');
+    setBookState(BOOK_STATE.COVER_FRONT);
   }
 
   function closingBack() {
-    if (bookState !== 'open') return;
-    setBookState('closing-back');
+    if (bookState !== BOOK_STATE.OPEN) return;
+    setBookState(BOOK_STATE.CLOSING_BACK);
   }
 
   function onBackClosed() {
-    setBookState('cover-back');
+    setBookState(BOOK_STATE.COVER_BACK);
   }
 
   function openingBack() {
-    if (bookState !== 'cover-back') return;
-    setBookState('opening-back');
+    if (bookState !== BOOK_STATE.COVER_BACK) return;
+    setBookState(BOOK_STATE.OPENING_BACK);
   }
 
   return {

--- a/src/widgets/award/ui/Award.tsx
+++ b/src/widgets/award/ui/Award.tsx
@@ -8,7 +8,6 @@ import {
   YearCategory,
 } from '@features/award';
 import { useBreakpoint } from '@shared/lib/breakpoint';
-import { lockScroll, unlockScroll } from '@shared/lib/useScrollLock';
 
 import { getItemsPerPage } from '../model/responsive';
 import '../styles/Award.css';
@@ -28,16 +27,6 @@ export function Award() {
     handleYearChange: changeYear,
   } = useYearFilter();
   const [selectedId, setSelectedId] = useState<number | null>(null);
-
-  function handleCardClick(id: number) {
-    lockScroll();
-    setSelectedId(id);
-  }
-
-  function handlePopupClose() {
-    unlockScroll();
-    setSelectedId(null);
-  }
 
   function handleYearChange(year: string | number): void {
     changeYear(year);
@@ -75,7 +64,7 @@ export function Award() {
           totalPages={totalPages}
           filteredList={filteredList}
           itemsPerPage={itemsPerPage}
-          onCardClick={handleCardClick}
+          onCardClick={setSelectedId}
           setCurrentPage={setCurrentPage}
         />
         {showPagination && (
@@ -92,7 +81,7 @@ export function Award() {
               AWARD_LIST.find((a) => a.id === selectedId)?.title ??
               '수상 이미지'
             }
-            onClose={handlePopupClose}
+            onClose={() => setSelectedId(null)}
           />
         )}
       </div>

--- a/src/widgets/award/ui/Award.tsx
+++ b/src/widgets/award/ui/Award.tsx
@@ -77,10 +77,7 @@ export function Award() {
         {selectedId !== null && (
           <AwardPopup
             awardId={selectedId}
-            awardTitle={
-              AWARD_LIST.find((a) => a.id === selectedId)?.title ??
-              '수상 이미지'
-            }
+            awardTitle={AWARD_LIST[selectedId].title ?? '수상 이미지'}
             onClose={() => setSelectedId(null)}
           />
         )}

--- a/src/widgets/award/ui/Popup.test.tsx
+++ b/src/widgets/award/ui/Popup.test.tsx
@@ -39,12 +39,12 @@ describe('AwardPopup', () => {
       render(
         <AwardPopup awardId={3} awardTitle='최우수상' onClose={vi.fn()} />,
       );
-      expect(screen.getByAltText('최우수상')).toBeInTheDocument();
+      expect(screen.getByAltText('최우수상 수상 이미지')).toBeInTheDocument();
     });
 
     it('이미지 src가 getAwardImage 반환값이다', () => {
       render(<AwardPopup awardId={1} awardTitle='우수상' onClose={vi.fn()} />);
-      expect(screen.getByAltText('우수상')).toHaveAttribute(
+      expect(screen.getByAltText('우수상 수상 이미지')).toHaveAttribute(
         'src',
         'popup-image.webp',
       );

--- a/src/widgets/award/ui/Popup.tsx
+++ b/src/widgets/award/ui/Popup.tsx
@@ -12,7 +12,11 @@ export function AwardPopup({
 }) {
   return (
     <Popup ariaLabel={`${awardTitle} 수상 이미지`} onClose={onClose}>
-      <img src={getAwardImage(awardId)} alt={awardTitle} loading='lazy' />
+      <img
+        src={getAwardImage(awardId)}
+        alt={`${awardTitle} 수상 이미지`}
+        loading='lazy'
+      />
     </Popup>
   );
 }

--- a/src/widgets/history/ui/History.tsx
+++ b/src/widgets/history/ui/History.tsx
@@ -5,6 +5,7 @@ import { PAGE_SIDE, RAPID_FLIP_DURATION } from '@features/history';
 import type { IndexItem } from '@features/history';
 import { useBookCoverState } from '@features/history';
 import { useBookNavigation } from '@features/history';
+import { BOOK_STATE } from '@features/history';
 import { useBreakpoint } from '@shared/lib/breakpoint';
 
 import '../styles/History.css';
@@ -56,13 +57,13 @@ export function History() {
   useEffect(() => {
     syncBoundaryCallbacks(
       (duration) => {
-        if (bookState === 'open' && !isAnimatingRef.current) {
+        if (bookState === BOOK_STATE.OPEN && !isAnimatingRef.current) {
           closingFront();
           startFlipAnimation('backward', onFrontClosed, duration);
         }
       },
       (duration) => {
-        if (bookState === 'open' && !isAnimatingRef.current) {
+        if (bookState === BOOK_STATE.OPEN && !isAnimatingRef.current) {
           closingBack();
           startFlipAnimation('forward', onBackClosed, duration);
         }
@@ -93,7 +94,7 @@ export function History() {
 
   useEffect(() => {
     if (
-      bookState === 'open' &&
+      bookState === BOOK_STATE.OPEN &&
       pendingCategory !== null &&
       !pendingFiredRef.current
     ) {
@@ -188,7 +189,7 @@ export function History() {
 
   function handleLeftMouseDown() {
     if (!canGoLeft) {
-      if (bookState === 'open' && !isAnimatingRef.current) {
+      if (bookState === BOOK_STATE.OPEN && !isAnimatingRef.current) {
         closingFront();
         startFlipAnimation('backward', onFrontClosed);
       }
@@ -199,7 +200,7 @@ export function History() {
 
   function handleRightMouseDown() {
     if (!canGoRight) {
-      if (bookState === 'open' && !isAnimatingRef.current) {
+      if (bookState === BOOK_STATE.OPEN && !isAnimatingRef.current) {
         closingBack();
         startFlipAnimation('forward', onBackClosed);
       }

--- a/src/widgets/history/ui/ImageGalleryPopup.tsx
+++ b/src/widgets/history/ui/ImageGalleryPopup.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useLayoutEffect } from 'react';
+import { useEffect } from 'react';
 
-import { lockScroll, unlockScroll } from '@shared/lib/useScrollLock';
 import { ImageSlider, useSliderNavigation } from '@shared/ui/ImageSlider';
 import { Popup } from '@shared/ui/Popup';
 
@@ -24,11 +23,6 @@ export function ImageGalleryPopup({
     startContinuousSlide,
     stopContinuousSlide,
   } = useSliderNavigation(images.length);
-
-  useLayoutEffect(() => {
-    lockScroll();
-    return unlockScroll;
-  }, []);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {

--- a/src/widgets/map/model/constant.ts
+++ b/src/widgets/map/model/constant.ts
@@ -1,0 +1,7 @@
+export const MAP_STATE = {
+  LOADING: 'loading',
+  READY: 'ready',
+  FALLBACK: 'fallback',
+};
+
+export type MapState = (typeof MAP_STATE)[keyof typeof MAP_STATE];

--- a/src/widgets/map/ui/Map.tsx
+++ b/src/widgets/map/ui/Map.tsx
@@ -115,7 +115,6 @@ export function Map() {
           <div
             ref={mapRef}
             className='map__content'
-            role='img'
             aria-label='인들이앤에이치 본사 위치 지도'
           />
         )}

--- a/src/widgets/map/ui/Map.tsx
+++ b/src/widgets/map/ui/Map.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 
 import { COMPANY } from '@shared/constant';
 
+import { MAP_STATE, type MapState } from '../model/constant';
 import { makeMap } from '../model/map';
 import '../styles/Map.css';
 import { MapCard } from './MapCard';
@@ -18,8 +19,6 @@ type NaverWindow = {
   navermap_authFailure?: () => void;
 };
 
-type MapState = 'loading' | 'ready' | 'fallback';
-
 const BBOX_OFFSET = 0.01;
 const FALLBACK_MAP_URL = [
   'https://www.openstreetmap.org/export/embed.html',
@@ -29,17 +28,17 @@ const FALLBACK_MAP_URL = [
 ].join('');
 
 function isNaverAvailable() {
-  const w = window as unknown as NaverWindow;
+  const w = window as NaverWindow;
   return !!w.naver?.maps?.Map;
 }
 
 export function Map() {
   const mapRef = useRef<HTMLDivElement>(null);
   const [mapState, setMapState] = useState<MapState>(() => {
-    if (isNaverAvailable()) return 'ready';
+    if (isNaverAvailable()) return MAP_STATE.READY;
     const key = import.meta.env.VITE_NAVER_MAP_API_KEY as string | undefined;
-    if (!key) return 'fallback';
-    return 'loading';
+    if (!key) return MAP_STATE.FALLBACK;
+    return MAP_STATE.LOADING;
   });
 
   // Naver Maps SDK 동적 주입 — Map 컴포넌트 마운트 시점으로 지연
@@ -50,7 +49,7 @@ export function Map() {
     if (!key) return;
 
     const handleLoad = () =>
-      setMapState(isNaverAvailable() ? 'ready' : 'fallback');
+      setMapState(isNaverAvailable() ? MAP_STATE.READY : MAP_STATE.FALLBACK);
 
     const existing = document.querySelector(
       'script[src*="oapi.map.naver.com"]',
@@ -70,7 +69,7 @@ export function Map() {
     script.src = `https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${key}`;
     script.async = true;
     script.onload = handleLoad;
-    script.onerror = () => setMapState('fallback');
+    script.onerror = () => setMapState(MAP_STATE.FALLBACK);
     document.head.appendChild(script);
 
     return () => {
@@ -81,18 +80,18 @@ export function Map() {
 
   // 지도 초기화 — SDK 준비 완료 후 실행
   useEffect(() => {
-    if (mapState !== 'ready' || !mapRef.current) return;
+    if (mapState !== MAP_STATE.READY || !mapRef.current) return;
 
     const w = window as unknown as NaverWindow;
 
     // 인증 실패(401 등) 시 Naver Maps SDK가 호출하는 공식 콜백
-    w.navermap_authFailure = () => setMapState('fallback');
+    w.navermap_authFailure = () => setMapState(MAP_STATE.FALLBACK);
 
     let cleanup: (() => void) | undefined;
     try {
       cleanup = makeMap(mapRef.current, INFO_CARD_HTML, MARKER_SVG);
     } catch {
-      queueMicrotask(() => setMapState('fallback'));
+      queueMicrotask(() => setMapState(MAP_STATE.FALLBACK));
     }
 
     return () => {
@@ -105,7 +104,7 @@ export function Map() {
     <section id='map' className='map' aria-label='찾아오시는 길'>
       <MapTitle />
       <div className='map__card'>
-        {mapState === 'fallback' ? (
+        {mapState === MAP_STATE.FALLBACK ? (
           <iframe
             className='map__content map__content--fallback'
             src={FALLBACK_MAP_URL}

--- a/src/widgets/patent/ui/Popup.stories.tsx
+++ b/src/widgets/patent/ui/Popup.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { PatentPopup } from './Popup';
+
+const meta = {
+  title: 'Widgets/Patent/Popup',
+  component: PatentPopup,
+  args: {
+    onClose: fn(),
+    patentId: 0,
+    patentTitle: '특허증 이미지',
+  },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          '특허증 카드 클릭 시 열리는 팝업. 해당 특허증 이미지를 전체화면 오버레이로 표시하며, 닫기 버튼 또는 배경 클릭으로 닫힙니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof PatentPopup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '팝업 열림',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '팝업이 열렸을 때의 모습. 전체화면 오버레이로 특허증 이미지가 표시되고, 닫기 버튼이 우측 상단에 위치합니다.',
+      },
+    },
+  },
+};

--- a/src/widgets/patent/ui/Popup.test.tsx
+++ b/src/widgets/patent/ui/Popup.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PatentPopup } from './Popup';
+
+vi.mock('@entities/patent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@entities/patent')>();
+  return {
+    ...actual,
+    getPatentImage: vi.fn().mockReturnValue('popup-image.webp'),
+  };
+});
+
+describe('PatentPopup', () => {
+  describe('렌더링', () => {
+    it('dialog 역할로 렌더링된다', () => {
+      render(
+        <PatentPopup patentId={1} patentTitle='의자 특허' onClose={vi.fn()} />,
+      );
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('aria-modal="true"가 설정된다', () => {
+      render(
+        <PatentPopup patentId={1} patentTitle='의자 특허' onClose={vi.fn()} />,
+      );
+      expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+    });
+
+    it('aria-label에 특허증 제목이 포함된다', () => {
+      render(
+        <PatentPopup patentId={1} patentTitle='의자 특허' onClose={vi.fn()} />,
+      );
+      expect(
+        screen.getByRole('dialog', { name: '의자 특허 특허증 이미지' }),
+      ).toBeInTheDocument();
+    });
+
+    it('닫기 버튼이 렌더링된다', () => {
+      render(
+        <PatentPopup patentId={1} patentTitle='의자 특허' onClose={vi.fn()} />,
+      );
+      expect(screen.getByRole('button', { name: '닫기' })).toBeInTheDocument();
+    });
+
+    it('이미지 alt 텍스트에 특허증 제목이 포함된다', () => {
+      render(
+        <PatentPopup patentId={3} patentTitle='의자 특허' onClose={vi.fn()} />,
+      );
+      expect(
+        screen.getByAltText('의자 특허 특허증 이미지'),
+      ).toBeInTheDocument();
+    });
+
+    it('이미지 src가 getPatentImage 반환값이다', () => {
+      render(
+        <PatentPopup patentId={1} patentTitle='의자 특허' onClose={vi.fn()} />,
+      );
+      expect(screen.getByAltText('의자 특허 특허증 이미지')).toHaveAttribute(
+        'src',
+        'popup-image.webp',
+      );
+    });
+  });
+
+  describe('닫기 동작', () => {
+    it('닫기 버튼 클릭 시 onClose가 호출된다', () => {
+      const onClose = vi.fn();
+      render(
+        <PatentPopup patentId={1} patentTitle='의자 특허' onClose={onClose} />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: '닫기' }));
+
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('오버레이 클릭 시 onClose가 호출된다', () => {
+      const onClose = vi.fn();
+      const { container } = render(
+        <PatentPopup patentId={1} patentTitle='의자 특허' onClose={onClose} />,
+      );
+      const overlay = container.querySelector('.popup__overlay')!;
+
+      fireEvent.click(overlay);
+
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('팝업 내부 클릭 시 onClose가 호출되지 않는다 (stopPropagation)', () => {
+      const onClose = vi.fn();
+      render(
+        <PatentPopup patentId={1} patentTitle='의자 특허' onClose={onClose} />,
+      );
+
+      fireEvent.click(screen.getByRole('dialog'));
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/widgets/patent/ui/Popup.tsx
+++ b/src/widgets/patent/ui/Popup.tsx
@@ -1,4 +1,4 @@
-import { getPatentImage, PATENT_VALID_LIST } from '@entities/patent';
+import { getPatentImage } from '@entities/patent';
 import { Popup } from '@shared/ui/Popup';
 
 export function PatentPopup({
@@ -14,7 +14,7 @@ export function PatentPopup({
     <Popup ariaLabel={`${patentTitle} 특허증 이미지`} onClose={onClose}>
       <img
         src={getPatentImage(patentId)}
-        alt={PATENT_VALID_LIST[patentId].title}
+        alt={`${patentTitle} 특허증 이미지`}
         loading='lazy'
       />
     </Popup>

--- a/src/widgets/patent/ui/Popup.tsx
+++ b/src/widgets/patent/ui/Popup.tsx
@@ -1,0 +1,22 @@
+import { getPatentImage, PATENT_VALID_LIST } from '@entities/patent';
+import { Popup } from '@shared/ui/Popup';
+
+export function PatentPopup({
+  patentId,
+  patentTitle,
+  onClose,
+}: {
+  patentId: number;
+  patentTitle: string;
+  onClose: () => void;
+}) {
+  return (
+    <Popup ariaLabel={`${patentTitle} 특허증 이미지`} onClose={onClose}>
+      <img
+        src={getPatentImage(patentId)}
+        alt={PATENT_VALID_LIST[patentId].title}
+        loading='lazy'
+      />
+    </Popup>
+  );
+}

--- a/src/widgets/patent/ui/ValidContent.test.tsx
+++ b/src/widgets/patent/ui/ValidContent.test.tsx
@@ -33,33 +33,5 @@ describe('PatentValidContent', () => {
       fireEvent.click(cards[0]);
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
-
-    it('팝업이 열리면 첫 번째 특허 제목이 aria-label로 설정된다', () => {
-      render(<PatentValidContent />);
-      fireEvent.click(screen.getAllByRole('button')[0]);
-      expect(
-        screen.getByRole('dialog', { name: PATENT_VALID_LIST[0].title }),
-      ).toBeInTheDocument();
-    });
-
-    it('두 번째 카드 클릭 시 두 번째 특허 팝업이 열린다', () => {
-      render(<PatentValidContent />);
-      fireEvent.click(screen.getAllByRole('button')[1]);
-      expect(
-        screen.getByRole('dialog', { name: PATENT_VALID_LIST[1].title }),
-      ).toBeInTheDocument();
-    });
-
-    it('팝업 닫기 버튼 클릭 시 팝업이 닫힌다', () => {
-      render(<PatentValidContent />);
-      fireEvent.click(screen.getAllByRole('button')[0]);
-      fireEvent.click(screen.getByRole('button', { name: '닫기' }));
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    });
-
-    it('팝업이 없는 초기 상태에서 dialog가 렌더링되지 않는다', () => {
-      render(<PatentValidContent />);
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    });
   });
 });

--- a/src/widgets/patent/ui/ValidContent.test.tsx
+++ b/src/widgets/patent/ui/ValidContent.test.tsx
@@ -1,13 +1,8 @@
 import { PATENT_VALID_LIST } from '@entities/patent';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { PatentValidContent } from './ValidContent';
-
-vi.mock('@shared/lib/useScrollLock', () => ({
-  lockScroll: vi.fn(),
-  unlockScroll: vi.fn(),
-}));
 
 describe('PatentValidContent', () => {
   it('유효 특허 건수가 표시된다', () => {

--- a/src/widgets/patent/ui/ValidContent.tsx
+++ b/src/widgets/patent/ui/ValidContent.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { FaRegCheckCircle } from 'react-icons/fa';
 
 import { getPatentImage, PATENT_VALID_LIST } from '@entities/patent';
-import { lockScroll, unlockScroll } from '@shared/lib/useScrollLock';
 import { Popup } from '@shared/ui/Popup';
 
 import '../styles/ValidContent.css';
@@ -10,16 +9,6 @@ import { PatentCard } from './PatentCard';
 
 export function PatentValidContent() {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-
-  function handleOpen(index: number) {
-    lockScroll();
-    setSelectedIndex(index);
-  }
-
-  function handleClose() {
-    unlockScroll();
-    setSelectedIndex(null);
-  }
 
   return (
     <article className='patent__content'>
@@ -36,14 +25,14 @@ export function PatentValidContent() {
       <ul className='patent__content__item__list'>
         {PATENT_VALID_LIST.map((item, index) => (
           <li key={item.serialNumber}>
-            <PatentCard item={item} onClick={() => handleOpen(index)} />
+            <PatentCard item={item} onClick={() => setSelectedIndex(index)} />
           </li>
         ))}
       </ul>
       {selectedIndex !== null && (
         <Popup
           ariaLabel={PATENT_VALID_LIST[selectedIndex].title}
-          onClose={handleClose}
+          onClose={() => setSelectedIndex(null)}
         >
           <img
             src={getPatentImage(selectedIndex)}

--- a/src/widgets/patent/ui/ValidContent.tsx
+++ b/src/widgets/patent/ui/ValidContent.tsx
@@ -1,14 +1,14 @@
 import { useState } from 'react';
 import { FaRegCheckCircle } from 'react-icons/fa';
 
-import { getPatentImage, PATENT_VALID_LIST } from '@entities/patent';
-import { Popup } from '@shared/ui/Popup';
+import { PATENT_VALID_LIST } from '@entities/patent';
 
 import '../styles/ValidContent.css';
 import { PatentCard } from './PatentCard';
+import { PatentPopup } from './Popup';
 
 export function PatentValidContent() {
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
 
   return (
     <article className='patent__content'>
@@ -25,21 +25,16 @@ export function PatentValidContent() {
       <ul className='patent__content__item__list'>
         {PATENT_VALID_LIST.map((item, index) => (
           <li key={item.serialNumber}>
-            <PatentCard item={item} onClick={() => setSelectedIndex(index)} />
+            <PatentCard item={item} onClick={() => setSelectedId(index)} />
           </li>
         ))}
       </ul>
-      {selectedIndex !== null && (
-        <Popup
-          ariaLabel={PATENT_VALID_LIST[selectedIndex].title}
-          onClose={() => setSelectedIndex(null)}
-        >
-          <img
-            src={getPatentImage(selectedIndex)}
-            alt={PATENT_VALID_LIST[selectedIndex].title}
-            loading='lazy'
-          />
-        </Popup>
+      {selectedId !== null && (
+        <PatentPopup
+          patentId={selectedId}
+          patentTitle={PATENT_VALID_LIST[selectedId].title}
+          onClose={() => setSelectedId(null)}
+        />
       )}
     </article>
   );


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### 핵심 변화

#### 변경 전
- 문자열 하드 코딩으로 인한 코드 유지보수 어려움
- Patent Popup이 Award Popup과 History/Content Image Gallery와 다르게 Wrapper 사용 안함 -> 데이터 불러오는 코드 가독성 저하

#### 변경 후
- 객체화로 IDE 자동 완성 기능 사용 가능 및 문자열 변경 용이
- Patent Popup Wrapping

# 📋 작업 내용

- lockScroll 불필요한 곳들 제거
- map 접근성 role 제거
- 문자열 하드 코딩 값들 객체 치환
- readme 수정
- Patent Popup 분리
- Award 불필요 데이터 로드 과정 제거
