### PR TITLE
👹 fix: award, patent 팝업 이미지 로드 느린 문제 해결

### DIFF
--- a/src/features/history/model/helpers.ts
+++ b/src/features/history/model/helpers.ts
@@ -1,9 +1,8 @@
 import { artworks, getThumbnailImage } from '@entities/history';
+import { preloadImages } from '@shared/lib/preload/preloadImages';
 
 import { PAGE_SIDE } from './constants';
 import type { PageSide } from './types';
-
-const preloadedSrcs = new Set<string>();
 
 export function getArtworkIndex(pageIndex: number, side: PageSide): number {
   const isLeft = side === PAGE_SIDE.LEFT;
@@ -18,13 +17,9 @@ export function preloadContentImages(pageIndex: number): void {
     getArtworkIndex(pageIndex - 1, 'right'),
   ];
 
-  for (const idx of adjacentIndices) {
-    if (idx < 0 || idx >= artworks.length) continue;
-    const src = getThumbnailImage(idx);
-    if (src && !preloadedSrcs.has(src)) {
-      preloadedSrcs.add(src);
-      const img = new Image();
-      img.src = src;
-    }
-  }
+  preloadImages(
+    adjacentIndices
+      .filter((idx) => idx >= 0 && idx < artworks.length)
+      .map((idx) => getThumbnailImage(idx)),
+  );
 }

--- a/src/shared/lib/preload/preloadImages.ts
+++ b/src/shared/lib/preload/preloadImages.ts
@@ -1,0 +1,10 @@
+const preloaded = new Set<string>();
+
+export function preloadImages(urls: (string | undefined)[]): void {
+  for (const url of urls) {
+    if (!url || preloaded.has(url)) continue;
+    preloaded.add(url);
+    const img = new Image();
+    img.src = url;
+  }
+}

--- a/src/shared/lib/preload/usePreloadOnVisible.ts
+++ b/src/shared/lib/preload/usePreloadOnVisible.ts
@@ -1,5 +1,7 @@
 import { type RefObject, useEffect } from 'react';
 
+import { preloadImages } from './preloadImages';
+
 export function usePreloadOnVisible(
   ref: RefObject<HTMLElement | null>,
   urls: string[],
@@ -11,11 +13,7 @@ export function usePreloadOnVisible(
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (!entry.isIntersecting) return;
-        urls.forEach((url) => {
-          if (!url) return;
-          const img = new Image();
-          img.src = url;
-        });
+        preloadImages(urls);
         observer.disconnect();
       },
       { rootMargin: '400px' },

--- a/src/shared/lib/preload/usePreloadOnVisible.ts
+++ b/src/shared/lib/preload/usePreloadOnVisible.ts
@@ -1,0 +1,28 @@
+import { type RefObject, useEffect } from 'react';
+
+export function usePreloadOnVisible(
+  ref: RefObject<HTMLElement | null>,
+  urls: string[],
+) {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || urls.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return;
+        urls.forEach((url) => {
+          if (!url) return;
+          const img = new Image();
+          img.src = url;
+        });
+        observer.disconnect();
+      },
+      { rootMargin: '400px' },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/src/widgets/award/ui/Award.tsx
+++ b/src/widgets/award/ui/Award.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
-import { AWARD_LIST } from '@entities/award';
+import { AWARD_LIST, getAwardImage } from '@entities/award';
 import {
   Pagination,
   useYearFilter,
@@ -8,6 +8,7 @@ import {
   YearCategory,
 } from '@features/award';
 import { useBreakpoint } from '@shared/lib/breakpoint';
+import { usePreloadOnVisible } from '@shared/lib/preload/usePreloadOnVisible';
 
 import { getItemsPerPage } from '../model/responsive';
 import '../styles/Award.css';
@@ -17,6 +18,13 @@ import { AwardPopup } from './Popup';
 import { Viewport } from './Viewport';
 
 export function Award() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const awardImageUrls = useMemo(
+    () => AWARD_LIST.map((award) => getAwardImage(award.id)),
+    [],
+  );
+  usePreloadOnVisible(sectionRef, awardImageUrls);
+
   const [currentPage, setCurrentPage] = useState(0);
   const breakpoint = useBreakpoint();
   const itemsPerPage = getItemsPerPage(breakpoint);
@@ -47,7 +55,12 @@ export function Award() {
   const safePage = Math.min(currentPage, Math.max(0, totalPages - 1));
 
   return (
-    <section id='award' className='award' aria-label='수상 기록'>
+    <section
+      ref={sectionRef}
+      id='award'
+      className='award'
+      aria-label='수상 기록'
+    >
       <div className='award__top'>
         <AwardTitle />
         <AwardCount awardList={AWARD_LIST} />

--- a/src/widgets/history/ui/ImageGalleryPopup.tsx
+++ b/src/widgets/history/ui/ImageGalleryPopup.tsx
@@ -25,6 +25,17 @@ export function ImageGalleryPopup({
   } = useSliderNavigation(images.length);
 
   useEffect(() => {
+    const len = images.length;
+    if (len <= 1) return;
+    const next = images[(currentIndex + 1) % len];
+    const prev = images[(currentIndex - 1 + len) % len];
+    [next, prev].forEach((url) => {
+      const img = new Image();
+      img.src = url;
+    });
+  }, [currentIndex, images]);
+
+  useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       e.stopImmediatePropagation();
       if (e.key === 'Escape') onClose();

--- a/src/widgets/history/ui/ImageGalleryPopup.tsx
+++ b/src/widgets/history/ui/ImageGalleryPopup.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 
+import { preloadImages } from '@shared/lib/preload/preloadImages';
 import { ImageSlider, useSliderNavigation } from '@shared/ui/ImageSlider';
 import { Popup } from '@shared/ui/Popup';
 
@@ -27,12 +28,10 @@ export function ImageGalleryPopup({
   useEffect(() => {
     const len = images.length;
     if (len <= 1) return;
-    const next = images[(currentIndex + 1) % len];
-    const prev = images[(currentIndex - 1 + len) % len];
-    [next, prev].forEach((url) => {
-      const img = new Image();
-      img.src = url;
-    });
+    preloadImages([
+      images[(currentIndex + 1) % len],
+      images[(currentIndex - 1 + len) % len],
+    ]);
   }, [currentIndex, images]);
 
   useEffect(() => {

--- a/src/widgets/patent/ui/ValidContent.tsx
+++ b/src/widgets/patent/ui/ValidContent.tsx
@@ -1,17 +1,24 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { FaRegCheckCircle } from 'react-icons/fa';
 
-import { PATENT_VALID_LIST } from '@entities/patent';
+import { getPatentImage, PATENT_VALID_LIST } from '@entities/patent';
+import { usePreloadOnVisible } from '@shared/lib/preload/usePreloadOnVisible';
 
 import '../styles/ValidContent.css';
 import { PatentCard } from './PatentCard';
 import { PatentPopup } from './Popup';
 
 export function PatentValidContent() {
+  const articleRef = useRef<HTMLElement>(null);
+  usePreloadOnVisible(
+    articleRef,
+    PATENT_VALID_LIST.map((_, i) => getPatentImage(i)),
+  );
+
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
   return (
-    <article className='patent__content'>
+    <article ref={articleRef} className='patent__content'>
       <header className='patent__content__title'>
         <div className='patent__content__title__text'>
           <FaRegCheckCircle


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

<!-- 이슈에 대한 작업이라면 PR과 이슈 연결 -->

- close #190

### 소주제1

- history 같은 경우 thumbnail에서 사용하는 이미지가 팝업의 첫번째 이미지라서 팝업이 열렸을 때 빠르게 로드되기에 어색함이 없었음
- patent와 award는 별도로 이미지 로드를 하지 않기 때문에 카드를 누르면서 팝업이 열림과 동시에 이미지 로드가 되어 팝업보다 이미지 로드가 느린 문제가 발생함

### 핵심 변화

#### 변경 전
- patent, award 프리 로드 없음

#### 변경 후
- patent, award 프리 로드 구현

# 📋 작업 내용

- patent, award 이미지 프리 로드
- 프리 로드 코드 shared 도메인으로 공유
