### PR TITLE
⚡️ perf: History 접근성 개선

### DIFF
--- a/src/features/history/model/events/useHoldNavigation.ts
+++ b/src/features/history/model/events/useHoldNavigation.ts
@@ -137,6 +137,7 @@ export function useHoldNavigation() {
         endContinuousFlip();
       else if (e.key === 'ArrowRight' && holdDirectionRef.current === 'right')
         endContinuousFlip();
+      else if (e.key === ' ' || e.key === 'Enter') endContinuousFlip();
     }
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);

--- a/src/shared/ui/Popup/styles/Popup.css
+++ b/src/shared/ui/Popup/styles/Popup.css
@@ -57,7 +57,7 @@
 }
 
 .popup__close {
-  font-size: max(19px, 1.342vw);
+  font-size: max(22px, 1.5625vw);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/widgets/history/ui/History.tsx
+++ b/src/widgets/history/ui/History.tsx
@@ -87,6 +87,9 @@ export function History() {
     );
   });
 
+  const [pageAnnouncement, setPageAnnouncement] = useState('');
+  const prevIsFlippingRef = useRef(false);
+
   const [pendingCategory, setPendingCategory] = useState<IndexItem | null>(
     null,
   );
@@ -227,8 +230,24 @@ export function History() {
 
   const pageIsFlipping = !isCoverFlip && isFlipping;
 
+  useEffect(() => {
+    const wasFlipping = prevIsFlippingRef.current;
+    prevIsFlippingRef.current = pageIsFlipping;
+    if (wasFlipping && !pageIsFlipping && bookState === BOOK_STATE.OPEN) {
+      setPageAnnouncement(`${activeItem} ${currentPageIndex + 1}페이지`);
+    }
+  }, [activeItem, currentPageIndex, pageIsFlipping, bookState]);
+
+  const leftAriaLabel = canGoLeft ? '이전 페이지로 이동' : '앞표지로 돌아가기';
+  const rightAriaLabel = canGoRight
+    ? '다음 페이지로 이동'
+    : '뒤표지로 돌아가기';
+
   return (
     <section id='history' className='history' aria-label='회사 역사'>
+      <div className='sr-only' aria-live='polite' aria-atomic='true'>
+        {pageAnnouncement}
+      </div>
       <HistoryTitle />
       <HistoryCategory
         tabActiveItem={tabActiveItem}
@@ -253,6 +272,7 @@ export function History() {
           onBackCoverClick={handleBackCoverClick}
           coverFrontContent={coverFrontContent}
           coverBackContent={coverBackContent}
+          ariaLabel={leftAriaLabel}
         />
         <BookSide
           side={PAGE_SIDE.RIGHT}
@@ -272,6 +292,7 @@ export function History() {
           onFrontCoverClick={handleFrontCoverClick}
           coverFrontContent={coverFrontContent}
           coverBackContent={coverBackContent}
+          ariaLabel={rightAriaLabel}
         />
       </div>
     </section>

--- a/src/widgets/history/ui/book/BookPageOuterShadow.tsx
+++ b/src/widgets/history/ui/book/BookPageOuterShadow.tsx
@@ -15,7 +15,7 @@ export function BookPageOuterShadow({
       : Array.from({ length: count }, (_, i) => i + 1);
 
   return (
-    <div className='history__book-page-outer-shadow'>
+    <div className='history__book-page-outer-shadow' aria-hidden='true'>
       {count
         ? levels.map((level) => (
             <div

--- a/src/widgets/history/ui/book/BookPageSide.tsx
+++ b/src/widgets/history/ui/book/BookPageSide.tsx
@@ -20,6 +20,7 @@ interface BookPageSideProps {
   isRapidFlipping?: boolean;
   isHoldChaining?: boolean;
   isHidden: boolean;
+  ariaLabel?: string;
 }
 
 export function BookPageSide({
@@ -35,6 +36,7 @@ export function BookPageSide({
   isRapidFlipping = false,
   isHoldChaining = false,
   isHidden,
+  ariaLabel,
 }: BookPageSideProps) {
   const isLeft = side === PAGE_SIDE.LEFT;
   const isRight = side === PAGE_SIDE.RIGHT;
@@ -53,6 +55,7 @@ export function BookPageSide({
         onMouseDown={onMouseDown}
         tabIndex={0}
         role='button'
+        aria-label={ariaLabel}
         onKeyDown={
           onMouseDown
             ? (e) => {

--- a/src/widgets/history/ui/book/BookPageSide.tsx
+++ b/src/widgets/history/ui/book/BookPageSide.tsx
@@ -51,6 +51,19 @@ export function BookPageSide({
       <div
         className={`history__book-page-${side} history__book-page-${side}--clickable${isHidden ? ' history__book-page-hidden' : ''}`}
         onMouseDown={onMouseDown}
+        tabIndex={0}
+        role='button'
+        onKeyDown={
+          onMouseDown
+            ? (e) => {
+                if (e.target !== e.currentTarget) return;
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  if (!e.repeat) onMouseDown();
+                }
+              }
+            : undefined
+        }
       >
         {isLeft ? (
           <BookPageOuterShadow side={side} count={shadowCount} />

--- a/src/widgets/history/ui/book/BookSide.tsx
+++ b/src/widgets/history/ui/book/BookSide.tsx
@@ -29,6 +29,7 @@ interface BookSideProps {
   onBackCoverClick?: () => void;
   coverFrontContent?: ReactNode;
   coverBackContent?: ReactNode;
+  ariaLabel?: string;
 }
 
 export function BookSide({
@@ -50,6 +51,7 @@ export function BookSide({
   onBackCoverClick,
   coverFrontContent,
   coverBackContent,
+  ariaLabel,
 }: BookSideProps) {
   const isLeft = side === PAGE_SIDE.LEFT;
   const isRight = side === PAGE_SIDE.RIGHT;
@@ -94,6 +96,7 @@ export function BookSide({
           isRapidFlipping={isRapidFlipping}
           isHoldChaining={isHoldChaining}
           isHidden={isHidden}
+          ariaLabel={ariaLabel}
         />
       )}
 

--- a/src/widgets/history/ui/book/content_container/Content.tsx
+++ b/src/widgets/history/ui/book/content_container/Content.tsx
@@ -86,12 +86,24 @@ function ContentItem({
     return () => ro.disconnect();
   }, [imageSrc]);
 
-  async function handleImageClick(e: React.MouseEvent) {
-    e.stopPropagation();
-    e.preventDefault();
+  async function openImageGallery() {
     const images = await getAllContentImages(index);
     setContentImages(images);
     setShowPopup(true);
+  }
+
+  function handleImageClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    e.preventDefault();
+    void openImageGallery();
+  }
+
+  function handleImageKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      void openImageGallery();
+    }
   }
 
   function handlePopupClose() {
@@ -162,13 +174,11 @@ function ContentItem({
         <figure
           className={`content__image${imageSrc ? ' content__image--has-image' : ''}`}
           onMouseDown={(e) => imageSrc && e.stopPropagation()}
-          onClick={
-            imageSrc
-              ? (e) => {
-                  void handleImageClick(e);
-                }
-              : undefined
-          }
+          onClick={imageSrc ? handleImageClick : undefined}
+          onKeyDown={imageSrc ? handleImageKeyDown : undefined}
+          role={imageSrc ? 'button' : undefined}
+          tabIndex={imageSrc ? 0 : undefined}
+          aria-label={imageSrc ? '이미지 확대 보기' : undefined}
         >
           {imageSrc && (
             <>

--- a/src/widgets/history/ui/book/content_container/List.tsx
+++ b/src/widgets/history/ui/book/content_container/List.tsx
@@ -34,11 +34,8 @@ export function ListPage({
               onMouseDown={
                 breakpoint !== 'mobile' ? (e) => e.stopPropagation() : undefined
               }
-              onClick={
-                breakpoint !== 'mobile'
-                  ? () => onItemClick?.(offset + i)
-                  : undefined
-              }
+              onKeyDown={(e) => e.stopPropagation()}
+              onClick={() => onItemClick?.(offset + i)}
             >
               {item.title}
             </button>

--- a/src/widgets/map/ui/MapCard.tsx
+++ b/src/widgets/map/ui/MapCard.tsx
@@ -28,7 +28,7 @@ export function MapCard() {
         ))}
       </ul>
 
-      <hr />
+      <hr aria-hidden='true' />
 
       <a href={`tel:${COMPANY.PHONE}`} className='map__description_call'>
         <FiPhoneCall aria-hidden='true' />

--- a/src/widgets/patent/ui/ExpireContent.tsx
+++ b/src/widgets/patent/ui/ExpireContent.tsx
@@ -15,7 +15,7 @@ export function PatentExpireContent() {
           />
           <h3>만료 특허 이력 ({PATENT_EXPIRE_LIST.length}건)</h3>
         </div>
-        <hr />
+        <hr aria-hidden='true' />
       </header>
       <ol className='patent__expiration__content'>
         {PATENT_EXPIRE_LIST.map((item, index) => (
@@ -29,7 +29,7 @@ export function PatentExpireContent() {
                 {item.serialNumber}
               </span>
             </div>
-            <hr />
+            <hr aria-hidden='true' />
           </li>
         ))}
       </ol>

--- a/src/widgets/patent/ui/ValidContent.tsx
+++ b/src/widgets/patent/ui/ValidContent.tsx
@@ -20,7 +20,7 @@ export function PatentValidContent() {
           />
           <h3>유효 특허증 ({PATENT_VALID_LIST.length}건)</h3>
         </div>
-        <hr />
+        <hr aria-hidden='true' />
       </header>
       <ul className='patent__content__item__list'>
         {PATENT_VALID_LIST.map((patent, index) => (


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #152

### History book Tab 기능 추가

- History Book에 커버에는 Tab이 갈 수 없어서 키보드 컨트롤이 불가능한 문제
- History Book Page에도 Tab이 갈 수 없어서 키보드 컨트롤이 불가능

### Aria 설정
- History 쪽 Aria 태그가 상당히 부족하다는 것을 인지.
- 스크린 리더 UX를 위해 Aria 태그 첨부

### 핵심 변화

#### 변경 전
- History Book에 커버에는 Tab이 갈 수 없어서 키보드 컨트롤이 불가능한 문제
- History Book Page에도 Tab이 갈 수 없어서 키보드 컨트롤이 불가능

#### 변경 후
- History Book Front Cover, Back Cover Tab 포커스 추가
- History Book Page에 Tab 포커스 추가

# 📋 작업 내용

- History Aria 태그 첨부
- History Book Front Cover, Back Cover, page clickable에 Tab 포커스 추가
