### PR TITLE
👹 fix: hero background white edge 제거

### DIFF
--- a/src/widgets/hero/styles/Hero.css
+++ b/src/widgets/hero/styles/Hero.css
@@ -12,18 +12,13 @@
   height: 100%;
   z-index: -1;
   filter: blur(10px);
+  transform: scale(1.2);
+  -webkit-transform: scale(1.2);
+  transform-origin: center;
 }
 
 .hero__background--fallback {
   object-fit: cover;
-}
-
-@media (max-width: 1024px) {
-  .hero__background {
-    transform: scale(1.2);
-    -webkit-transform: scale(1.2);
-    transform-origin: center;
-  }
 }
 
 .hero__company {


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #201

### 핵심 변화

#### 변경 전
- 카카오 인앱 브라우저, Safri(iOS), Chromium 68(TV)에서 테두리 하얀색 발생

#### 변경 후
- 카카오 인앱 브라우저, Safri(iOS), Chromium 68(TV)에서 테두리 하얀색 제거

# 📋 작업 내용

- Hero 배경 하얀색 테두리 제거 -> transform 으로 scale 확대

# 📷 스크린 샷 (선택 사항)

<img width="2245" height="930" alt="image" src="https://github.com/user-attachments/assets/577d6fd9-fdef-49e0-9e9d-bb4acd1af6b1" />
<img width="2242" height="928" alt="image" src="https://github.com/user-attachments/assets/e4adb42b-b110-44d0-a074-5060adef4ff5" />
