### PR TITLE
⚙️ chore: Lightning CSS 도입 및 webkit 접두사 제거

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@vitest/coverage-v8": "^4.1.2",
         "@vitest/ui": "^4.1.2",
         "babel-plugin-react-compiler": "^1.0.0",
+        "browserslist": "^4.28.2",
         "chromatic": "^16.3.0",
         "commitizen": "^4.3.1",
         "cross-env": "^10.1.0",
@@ -57,6 +58,7 @@
         "happy-dom": "^20.9.0",
         "husky": "^9.1.7",
         "jsdom": "^29.0.2",
+        "lightningcss": "^1.32.0",
         "lint-staged": "^15.5.2",
         "playwright": "^1.59.1",
         "prettier": "^3.8.3",
@@ -4708,9 +4710,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.10",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
-      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
+      "version": "2.10.27",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4819,9 +4821,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -4839,11 +4841,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4975,9 +4977,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "dev": true,
       "funding": [
         {
@@ -6307,9 +6309,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.325",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.325.tgz",
-      "integrity": "sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==",
+      "version": "1.5.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
       "dev": true,
       "license": "ISC"
     },
@@ -8852,9 +8854,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
-      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -8868,23 +8870,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.30.2",
-        "lightningcss-darwin-arm64": "1.30.2",
-        "lightningcss-darwin-x64": "1.30.2",
-        "lightningcss-freebsd-x64": "1.30.2",
-        "lightningcss-linux-arm-gnueabihf": "1.30.2",
-        "lightningcss-linux-arm64-gnu": "1.30.2",
-        "lightningcss-linux-arm64-musl": "1.30.2",
-        "lightningcss-linux-x64-gnu": "1.30.2",
-        "lightningcss-linux-x64-musl": "1.30.2",
-        "lightningcss-win32-arm64-msvc": "1.30.2",
-        "lightningcss-win32-x64-msvc": "1.30.2"
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
-      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
       ],
@@ -8903,9 +8905,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
-      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
@@ -8924,9 +8926,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
-      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
@@ -8945,9 +8947,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
-      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
@@ -8966,9 +8968,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
-      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
@@ -8987,13 +8989,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
-      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9008,13 +9013,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
-      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9029,13 +9037,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
-      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9050,13 +9061,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
-      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9071,9 +9085,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
-      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
@@ -9092,9 +9106,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
-      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@vitest/coverage-v8": "^4.1.2",
     "@vitest/ui": "^4.1.2",
     "babel-plugin-react-compiler": "^1.0.0",
+    "browserslist": "^4.28.2",
     "chromatic": "^16.3.0",
     "commitizen": "^4.3.1",
     "cross-env": "^10.1.0",
@@ -81,6 +82,7 @@
     "happy-dom": "^20.9.0",
     "husky": "^9.1.7",
     "jsdom": "^29.0.2",
+    "lightningcss": "^1.32.0",
     "lint-staged": "^15.5.2",
     "playwright": "^1.59.1",
     "prettier": "^3.8.3",
@@ -98,6 +100,7 @@
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
   },
+  "browserslist": ">= 0.25%",
   "config": {
     "commitizen": {
       "path": "cz-customizable"

--- a/src/pages/privacy-policy/styles/PrivacyPolicy.css
+++ b/src/pages/privacy-policy/styles/PrivacyPolicy.css
@@ -371,7 +371,6 @@
 .privacy-policy__back-btn:hover {
   background-color: var(--brown-600);
   transform: translateY(-0.052vmax);
-  -webkit-transform: translateY(-0.052vmax);
 }
 
 .privacy-policy__back-btn svg {

--- a/src/shared/ui/ImageSlider/styles/ImageSlider.css
+++ b/src/shared/ui/ImageSlider/styles/ImageSlider.css
@@ -48,7 +48,6 @@
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  -webkit-transform: translateY(-50%);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -86,7 +85,6 @@
   bottom: 0.8vmax;
   left: 50%;
   transform: translateX(-50%);
-  -webkit-transform: translateX(-50%);
   background: var(--overlay-black-50);
   color: var(--white);
   padding: 0.26vmax 0.78vmax;

--- a/src/shared/ui/InfoCard/styles/InfoCard.css
+++ b/src/shared/ui/InfoCard/styles/InfoCard.css
@@ -24,7 +24,6 @@
 
 .info-card:hover {
   transform: translateY(-0.3vmax);
-  -webkit-transform: translateY(-0.3vmax);
   box-shadow: 0 0.6vmax 1.2vmax var(--shadow-04);
 }
 
@@ -98,9 +97,6 @@
   color: var(--brown-800);
 
   width: 100%;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
   overflow: hidden;
   text-align: center;
 }

--- a/src/shared/ui/InfoCard/styles/InfoCard.css
+++ b/src/shared/ui/InfoCard/styles/InfoCard.css
@@ -96,6 +96,10 @@
 
   color: var(--brown-800);
 
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+
   width: 100%;
   overflow: hidden;
   text-align: center;

--- a/src/widgets/header/styles/Header.css
+++ b/src/widgets/header/styles/Header.css
@@ -31,12 +31,10 @@
 
 .header--hidden {
   transform: translateY(-100%);
-  -webkit-transform: translateY(-100%);
 }
 
 body[data-popup-open] .header {
   transform: translateY(-100%);
-  -webkit-transform: translateY(-100%);
 }
 
 .header__logo {

--- a/src/widgets/hero/styles/Hero.css
+++ b/src/widgets/hero/styles/Hero.css
@@ -13,7 +13,6 @@
   z-index: -1;
   filter: blur(10px);
   transform: scale(1.2);
-  -webkit-transform: scale(1.2);
   transform-origin: center;
 }
 
@@ -72,18 +71,15 @@
   0%,
   100% {
     transform: translateX(-50%) translateY(0);
-    -webkit-transform: translateX(-50%) translateY(0);
   }
   50% {
     transform: translateX(-50%) translateY(10px);
-    -webkit-transform: translateX(-50%) translateY(10px);
   }
 }
 
 .hero__down-icon {
   position: absolute;
   transform: translateX(-50%);
-  -webkit-transform: translateX(-50%);
   bottom: 2.5%;
   left: 50%;
   animation: bounce-down 2s ease-in-out infinite;
@@ -151,7 +147,6 @@
     bottom: 9.11vw;
     left: 50%;
     transform: translateX(-50%);
-    -webkit-transform: translateX(-50%);
     font-size: 4.56vw;
   }
 

--- a/src/widgets/history/styles/book/BackCover.css
+++ b/src/widgets/history/styles/book/BackCover.css
@@ -26,7 +26,6 @@
 
 .history__back-cover--centered {
   transform: translateX(50%);
-  -webkit-transform: translateX(50%);
 }
 
 .history__back-cover-spine {
@@ -61,7 +60,6 @@
   background: var(--gold-gradient);
   background-size: 200% auto;
 
-  -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
 
@@ -77,7 +75,6 @@
 
   .history__back-cover--centered {
     transform: translateY(50%);
-    -webkit-transform: translateY(50%);
   }
 
   .history__back-cover-spine {
@@ -105,7 +102,6 @@
 
   .history__back-cover--centered {
     transform: translateY(50%);
-    -webkit-transform: translateY(50%);
   }
 
   .history__back-cover-spine {

--- a/src/widgets/history/styles/book/BookPageSide.css
+++ b/src/widgets/history/styles/book/BookPageSide.css
@@ -2,7 +2,6 @@
   position: absolute;
   inset: 0;
   perspective: 120vmax;
-  -webkit-perspective: 120vmax;
   z-index: 10;
 }
 
@@ -89,7 +88,6 @@
 @media (max-width: 1024px) {
   .history__book-page-flip-wrapper {
     perspective: 2304px;
-    -webkit-perspective: 2304px;
   }
 
   .history__book-page-left {
@@ -154,7 +152,6 @@
 @media (max-width: 767px) {
   .history__book-page-flip-wrapper {
     perspective: 2304px;
-    -webkit-perspective: 2304px;
   }
 
   .history__book-page-left {

--- a/src/widgets/history/styles/book/CoverFlip.css
+++ b/src/widgets/history/styles/book/CoverFlip.css
@@ -3,7 +3,6 @@
   inset: 0;
   z-index: 15;
   perspective: 120vmax;
-  -webkit-perspective: 120vmax;
 }
 
 .history__book-cover-flip-panel {
@@ -19,13 +18,11 @@
 .history__book-cover-flip-panel--forward {
   left: 0%;
   transform-origin: left center;
-  -webkit-transform-origin: left center;
 }
 
 .history__book-cover-flip-panel--backward {
   right: 0%;
   transform-origin: right center;
-  -webkit-transform-origin: right center;
 }
 
 .history__book-cover-flip-front,
@@ -33,12 +30,10 @@
   position: absolute;
   inset: 0;
   backface-visibility: hidden;
-  -webkit-backface-visibility: hidden;
 }
 
 .history__book-cover-flip-front {
   transform: translateZ(0.01px);
-  -webkit-transform: translateZ(0.01px);
 }
 
 .history__book-cover-flip-front-inner,
@@ -72,21 +67,18 @@
 @media (max-width: 1024px) {
   .history__book-cover-flip {
     perspective: 2304px;
-    -webkit-perspective: 2304px;
   }
 
   .history__book-cover-flip-panel--forward {
     left: 0;
     top: 0%;
     transform-origin: top;
-    -webkit-transform-origin: top;
   }
 
   .history__book-cover-flip-panel--backward {
     right: 0;
     bottom: 0%;
     transform-origin: bottom;
-    -webkit-transform-origin: bottom;
   }
 
   .history__book-cover-flip-panel--forward
@@ -113,7 +105,6 @@
 @media (max-width: 767px) {
   .history__book-cover-flip {
     perspective: 2304px;
-    -webkit-perspective: 2304px;
   }
 
   .history__book-cover-flip-panel--forward

--- a/src/widgets/history/styles/book/FrontCover.css
+++ b/src/widgets/history/styles/book/FrontCover.css
@@ -30,7 +30,6 @@
 
 .history__front-cover--centered {
   transform: translateX(-50%);
-  -webkit-transform: translateX(-50%);
 }
 
 .history__front-cover-spine {
@@ -61,7 +60,6 @@
   background: var(--gold-gradient);
   background-size: 200% auto;
 
-  -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
 
@@ -95,7 +93,6 @@
   font-weight: var(--bookendbatang-bold);
 
   transform: skewX(-10deg);
-  -webkit-transform: skewX(-10deg);
 }
 
 .history__front-cover-year-number {
@@ -121,7 +118,6 @@
 
   .history__front-cover--centered {
     transform: translateY(-50%);
-    -webkit-transform: translateY(-50%);
   }
 
   .history__front-cover-spine {

--- a/src/widgets/history/styles/book/PageFlip.css
+++ b/src/widgets/history/styles/book/PageFlip.css
@@ -26,14 +26,12 @@
   left: 0;
   right: 0;
   transform-origin: left center;
-  -webkit-transform-origin: left center;
 }
 
 .history__book-page-flip-panel--backward {
   left: 0;
   right: 0;
   transform-origin: right center;
-  -webkit-transform-origin: right center;
 }
 
 .history__book-page-flip-front,
@@ -41,7 +39,6 @@
   position: absolute;
   inset: 0;
   backface-visibility: hidden;
-  -webkit-backface-visibility: hidden;
   z-index: auto;
 }
 
@@ -62,12 +59,10 @@
 
   .history__book-page-flip-panel--forward {
     transform-origin: top;
-    -webkit-transform-origin: top;
   }
 
   .history__book-page-flip-panel--backward {
     transform-origin: bottom;
-    -webkit-transform-origin: bottom;
   }
 }
 

--- a/src/widgets/history/styles/book/content_container/Content.css
+++ b/src/widgets/history/styles/book/content_container/Content.css
@@ -164,7 +164,6 @@
 
 .content__image--has-image:hover img {
   transform: scale(1.07);
-  -webkit-transform: scale(1.07);
 }
 
 .content__image-zoom {

--- a/src/widgets/map/styles/MapCard.css
+++ b/src/widgets/map/styles/MapCard.css
@@ -109,7 +109,6 @@
   background-color: var(--brown-900);
   box-shadow: none;
   transform: translateY(1px);
-  -webkit-transform: translateY(1px);
 }
 
 .map__description_call svg {

--- a/src/widgets/vision/styles/VisionItem.css
+++ b/src/widgets/vision/styles/VisionItem.css
@@ -44,7 +44,6 @@
 
 .vision__content:hover .vision__content__image img {
   transform: scale(1.08);
-  -webkit-transform: scale(1.08);
 }
 
 .vision__content__text {
@@ -87,7 +86,6 @@
   font-size: max(40px, 3.13vw);
   color: var(--color-main-h3);
   transform: skewX(-10deg);
-  -webkit-transform: skewX(-10deg);
 }
 
 .vision__content__title__main h4 {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,14 @@
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import browserslist from 'browserslist';
+import { browserslistToTargets } from 'lightningcss';
+import { defineConfig, type UserConfig } from 'vite';
 import sitemap from 'vite-plugin-sitemap';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 const isStorybook =
   process.env.STORYBOOK === 'true' || process.env.CHROMATIC === 'true';
 
-export const baseConfig = {
+export const baseConfig: UserConfig = {
   plugins: [
     react({
       babel: {
@@ -20,8 +22,15 @@ export const baseConfig = {
     host: true,
     port: 5173,
   },
+  css: {
+    transformer: 'lightningcss',
+    lightningcss: {
+      targets: browserslistToTargets(browserslist('>= 0.25%')),
+    },
+  },
   build: {
     target: 'esnext',
+    cssMinify: 'lightningcss',
     chunkSizeWarningLimit: 500,
     rollupOptions: {
       output: {


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #108 

### Lightning CSS란?

Lightning CSS는 Rust로 작성된 초고속 CSS 파서·트랜스파이러·번들러·미니파이어입니다.

- **속도**: PostCSS + cssnano 대비 압도적으로 빠른 처리 속도 (Rust 기반)
- **자동 vendor prefix**: browserslist 타겟에 따라 `-webkit-`, `-moz-` 등 벤더 접두사를 자동으로 추가·제거
- **최신 CSS 다운레벨**: CSS Nesting, `color-mix()`, custom properties 등 최신 문법을 대상 브라우저에 맞게 자동 변환
- **CSS 압축**: 프로덕션 빌드 시 CSS 최소화 담당

### 프로젝트 적용 방식

| 설정 항목 | 적용 내용 |
|---|---|
| `css.transformer` | `'lightningcss'` — PostCSS 대신 Lightning CSS로 CSS 변환 파이프라인 교체 |
| `css.lightningcss.targets` | `browserslistToTargets(browserslist('>= 0.25%'))` — 프로젝트 browserslist 기준으로 브라우저 타겟 자동 산출 |
| `build.cssMinify` | `'lightningcss'` — 프로덕션 빌드 시 CSS 압축을 Lightning CSS가 담당 |

### 핵심 변화

#### 변경 전
- Vite 기본 PostCSS 파이프라인 사용
- CSS 파일에 `-webkit-` 벤더 접두사를 수동으로 작성

#### 변경 후
- Lightning CSS가 CSS 변환 + 압축 전담
- browserslist 타겟에 맞춰 벤더 접두사 자동 처리 → 기존 수동 `-webkit-` 접두사 전체 제거
- 빌드 속도 향상 및 CSS 번들 크기 최적화

# 📋 작업 내용

- `lightningcss` v1.32.0 devDependency 추가
- `browserslist` devDependency 추가
- `vite.config.ts`에 Lightning CSS transformer 및 cssMinify 설정 추가
- `browserslistToTargets` + `browserslist('>= 0.25%')`로 브라우저 타겟 자동 연동
- 16개 CSS 파일에서 `-webkit-` 벤더 접두사 제거 (Lightning CSS가 자동 처리)