### PR TITLE
👹 fix: award viewport 가운데에 없는 문제

### DIFF
--- a/src/widgets/award/styles/Viewport.css
+++ b/src/widgets/award/styles/Viewport.css
@@ -4,8 +4,7 @@
 
   width: 100%;
   height: 93.3vh;
-  padding: 0.5vmax;
-  overflow-x: clip;
+  overflow: hidden;
 }
 
 .award__card_slider {
@@ -20,6 +19,8 @@
 
   flex: 0 0 100%;
   height: 100%;
+  padding: 0.5vmax;
+  overflow: hidden;
 
   grid-template-columns: repeat(5, 1fr);
   grid-template-rows: repeat(2, 1fr);
@@ -30,15 +31,12 @@
 
 @media (max-width: 1024px) {
   .award__card_viewport {
-    padding: 0.5vw;
     height: 69vh;
   }
 
-  .award__card_slider {
-    gap: 1.3vw;
-  }
-
   .award__card_page {
+    padding: 0.5vw;
+
     grid-template-columns: repeat(3, 1fr);
     grid-template-rows: repeat(2, 1fr);
 
@@ -49,15 +47,12 @@
 
 @media (max-width: 767px) {
   .award__card_viewport {
-    padding: clamp(3px, 1vw, 5px);
     height: 70.59vh;
   }
 
-  .award__card_slider {
-    gap: clamp(9px, 2.67vw, 13px);
-  }
-
   .award__card_page {
+    padding: clamp(3px, 1vw, 5px);
+
     grid-template-columns: repeat(2, 1fr);
     grid-template-rows: repeat(2, 1fr);
 

--- a/src/widgets/award/ui/Viewport.tsx
+++ b/src/widgets/award/ui/Viewport.tsx
@@ -60,7 +60,7 @@ export function Viewport() {
     >
       <motion.div
         className='award__card_slider'
-        animate={{ x: `calc(-${safePage * 100}% - ${safePage}vmax)` }}
+        animate={{ x: `-${safePage * 100}%` }}
         transition={{ type: 'tween', duration: 0.4, ease: 'easeOut' }}
       >
         {Array.from({ length: totalPages }, (_, pageIndex) => (


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #220 

### 핵심 변화

#### 변경 전
- calc로 움직임 계산
#### 변경 후
- calc 제거 및 page 자체에 padding 추가
- award__card_slider에 gap 제거

# 📋 작업 내용

- viewport X축 가운데에 존재하도록 변경