### PR TITLE
👹 fix: iOS history list 버튼 active 상태 됨

### DIFF
--- a/src/widgets/history/styles/book/content_container/List.css
+++ b/src/widgets/history/styles/book/content_container/List.css
@@ -77,5 +77,6 @@
 
   .list__ul button {
     font-size: clamp(8px, 2.133vw, 11px);
+    -webkit-tap-highlight-color: transparent;
   }
 }


### PR DESCRIPTION
<!--
```
- PR이 승인되면 해당 브랜치 삭제하기
```
-->

# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #227

### 핵심 변화

#### 변경 전
- ios 모바일에서 history/list 버튼 눌렀을 경우 기능은 없지만 버튼으로 인식하여 어색함 존재
#### 변경 후
- ios 모바일에서 history/list 버튼 눌렀을 경우 버튼으로 인식 안되게 구현

# 📋 작업 내용

- -webkit-tap-hightlight-color 추가하여 버튼 하이라이팅 제거
