### PR TITLE
👹 fix: hero 위젯 로고 밀리는 문제

### DIFF
--- a/src/widgets/hero/styles/Hero.css
+++ b/src/widgets/hero/styles/Hero.css
@@ -33,6 +33,7 @@
 
 .hero__logo {
   height: 16.67vmax;
+  aspect-ratio: 649 / 748;
   filter: drop-shadow(0 0 2.08vmax var(--black));
 }
 


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #225

### 핵심 변화

#### 변경 전
- 이미지 비율이 없어서 사전에 이미지 공간 확보 불가
#### 변경 후
- 이미지 비율을 작성하여 사전에 이미지 공간 확보를 통해 글자 밀림 해결

# 📋 작업 내용
- 이미지 비율 추가