### PR TITLE
⚙️ chore: baseUrl deprecated

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,14 +9,13 @@
     "skipLibCheck": true,
 
     /* Path Alias */
-    "baseUrl": ".",
     "paths": {
-      "@app/*": ["src/app/*"],
-      "@entities/*": ["src/entities/*"],
-      "@features/*": ["src/features/*"],
-      "@pages/*": ["src/pages/*"],
-      "@shared/*": ["src/shared/*"],
-      "@widgets/*": ["src/widgets/*"]
+      "@app/*": ["./src/app/*"],
+      "@entities/*": ["./src/entities/*"],
+      "@features/*": ["./src/features/*"],
+      "@pages/*": ["./src/pages/*"],
+      "@shared/*": ["./src/shared/*"],
+      "@widgets/*": ["./src/widgets/*"]
     },
 
     /* Bundler mode */


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### tsconfig.json baseUrl 제거

- Typescript 7.0 버전 이상부터 baseUrl이 deprecated 되어 제거하고 path alias 경로 앞 쪽에 `./`를 추가했습니다.

### 핵심 변화

#### 변경 전
- tsconfig baseUrl 존재
#### 변경 후
- tsconfig baseUrl 제거
- paths baseUrl 포함

# 📋 작업 내용

- tsconfig.json 수정
