### PR TITLE
🔨 refactor: storybook 스토리 개선

### DIFF
--- a/src/features/award/ui/Pagination.stories.tsx
+++ b/src/features/award/ui/Pagination.stories.tsx
@@ -1,23 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { fn } from 'storybook/test';
 
+import { useAwardStore } from '../model/useAwardStore';
 import { Pagination } from './Pagination';
 
 const meta = {
   title: 'Features/Award/Pagination',
   component: Pagination,
-  args: {
-    currentPage: 0,
-    totalPages: 5,
-    onPageChange: fn(),
-  },
   parameters: {
     layout: 'centered',
     docs: {
       description: {
         component:
-          'Award 위젯의 페이지네이션 컴포넌트. 현재 페이지와 총 페이지 수를 표시하며, 페이지 변경 시 onPageChange 콜백을 호출합니다.',
+          'Award 위젯의 페이지네이션 컴포넌트. Zustand 스토어에서 현재 페이지와 총 페이지 수를 계산하여 표시하며, 페이지 변경 시 스토어를 업데이트합니다.',
       },
+      story: { inline: false },
     },
   },
 } satisfies Meta<typeof Pagination>;
@@ -27,10 +23,16 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   name: '기본',
+  decorators: [
+    (Story) => {
+      useAwardStore.setState({ currentPage: 0, activeYear: '전체' });
+      return <Story />;
+    },
+  ],
   parameters: {
     docs: {
       description: {
-        story: '현재 페이지 0, 총 페이지 5인 기본 상태.',
+        story: '첫 번째 페이지 상태. 모바일 기준 총 3페이지 중 1페이지.',
       },
     },
   },
@@ -38,13 +40,16 @@ export const Default: Story = {
 
 export const MiddlePage: Story = {
   name: '중간 페이지',
-  args: {
-    currentPage: 2,
-  },
+  decorators: [
+    (Story) => {
+      useAwardStore.setState({ currentPage: 1, activeYear: '전체' });
+      return <Story />;
+    },
+  ],
   parameters: {
     docs: {
       description: {
-        story: '현재 페이지 2로 설정하여 중간 페이지 상태를 시뮬레이션.',
+        story: '중간 페이지 상태. 모바일 기준 총 3페이지 중 2페이지.',
       },
     },
   },
@@ -52,13 +57,16 @@ export const MiddlePage: Story = {
 
 export const LastPage: Story = {
   name: '마지막 페이지',
-  args: {
-    currentPage: 4,
-  },
+  decorators: [
+    (Story) => {
+      useAwardStore.setState({ currentPage: 2, activeYear: '전체' });
+      return <Story />;
+    },
+  ],
   parameters: {
     docs: {
       description: {
-        story: '현재 페이지 4로 설정하여 마지막 페이지 상태를 시뮬레이션.',
+        story: '마지막 페이지 상태. 모바일 기준 총 3페이지 중 3페이지.',
       },
     },
   },

--- a/src/features/award/ui/Pagination.stories.tsx
+++ b/src/features/award/ui/Pagination.stories.tsx
@@ -23,6 +23,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   name: '기본',
+  args: { totalPages: 3 },
   decorators: [
     (Story) => {
       useAwardStore.setState({ currentPage: 0, activeYear: '전체' });
@@ -32,7 +33,7 @@ export const Default: Story = {
   parameters: {
     docs: {
       description: {
-        story: '첫 번째 페이지 상태. 모바일 기준 총 3페이지 중 1페이지.',
+        story: '첫 번째 페이지 상태. 총 3페이지 중 1페이지.',
       },
     },
   },
@@ -40,6 +41,7 @@ export const Default: Story = {
 
 export const MiddlePage: Story = {
   name: '중간 페이지',
+  args: { totalPages: 3 },
   decorators: [
     (Story) => {
       useAwardStore.setState({ currentPage: 1, activeYear: '전체' });
@@ -49,7 +51,7 @@ export const MiddlePage: Story = {
   parameters: {
     docs: {
       description: {
-        story: '중간 페이지 상태. 모바일 기준 총 3페이지 중 2페이지.',
+        story: '중간 페이지 상태. 총 3페이지 중 2페이지.',
       },
     },
   },
@@ -57,6 +59,7 @@ export const MiddlePage: Story = {
 
 export const LastPage: Story = {
   name: '마지막 페이지',
+  args: { totalPages: 3 },
   decorators: [
     (Story) => {
       useAwardStore.setState({ currentPage: 2, activeYear: '전체' });
@@ -66,7 +69,7 @@ export const LastPage: Story = {
   parameters: {
     docs: {
       description: {
-        story: '마지막 페이지 상태. 모바일 기준 총 3페이지 중 3페이지.',
+        story: '마지막 페이지 상태. 총 3페이지 중 3페이지.',
       },
     },
   },

--- a/src/features/award/ui/Pagination.tsx
+++ b/src/features/award/ui/Pagination.tsx
@@ -10,7 +10,11 @@ import { getItemsPerPage } from '../model/responsive';
 import { useAwardStore } from '../model/useAwardStore';
 import '../styles/Pagination.css';
 
-export function Pagination() {
+export function Pagination({
+  totalPages: totalPagesProp,
+}: {
+  totalPages?: number;
+}) {
   const activeYear = useAwardStore((s) => s.activeYear);
   const currentPage = useAwardStore((s) => s.currentPage);
   const setCurrentPage = useAwardStore((s) => s.setCurrentPage);
@@ -27,7 +31,8 @@ export function Pagination() {
     return list;
   }, [activeYear]);
 
-  const totalPages = Math.ceil(filteredList.length / itemsPerPage);
+  const totalPages =
+    totalPagesProp ?? Math.ceil(filteredList.length / itemsPerPage);
   const safePage = Math.min(currentPage, Math.max(0, totalPages - 1));
 
   return (

--- a/src/features/award/ui/YearCategory.stories.tsx
+++ b/src/features/award/ui/YearCategory.stories.tsx
@@ -1,24 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { fn } from 'storybook/test';
 
 import { YEAR_LIST } from '../model/constant';
+import { useAwardStore } from '../model/useAwardStore';
 import { YearCategory } from './YearCategory';
 
 const meta = {
   title: 'Features/Award/YearCategory',
   component: YearCategory,
-  args: {
-    yearList: YEAR_LIST,
-    activeYear: '전체',
-    onYearChange: fn(),
-  },
   parameters: {
     layout: 'centered',
     docs: {
       description: {
         component:
-          'Award 위젯의 연도 카테고리 컴포넌트. 연도별로 수상 기록을 필터링하는 역할을 합니다.',
+          'Award 위젯의 연도 카테고리 컴포넌트. Zustand 스토어의 activeYear에 따라 활성 연도가 결정됩니다.',
       },
+      story: { inline: false },
     },
   },
 } satisfies Meta<typeof YearCategory>;
@@ -28,6 +24,12 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   name: '기본',
+  decorators: [
+    (Story) => {
+      useAwardStore.setState({ activeYear: '전체' });
+      return <Story />;
+    },
+  ],
   parameters: {
     docs: {
       description: {
@@ -40,14 +42,17 @@ export const Default: Story = {
 
 export const SelectedYear: Story = {
   name: '선택된 연도',
-  args: {
-    activeYear: YEAR_LIST[1],
-  },
+  decorators: [
+    (Story) => {
+      useAwardStore.setState({ activeYear: YEAR_LIST[1] });
+      return <Story />;
+    },
+  ],
   parameters: {
     docs: {
       description: {
         story:
-          '2020년이 선택된 상태를 시뮬레이션하여 해당 연도의 수상 기록이 필터링됩니다.',
+          '특정 연도가 선택된 상태를 시뮬레이션하여 해당 연도의 수상 기록이 필터링됩니다.',
       },
     },
   },

--- a/src/widgets/award/ui/AwardCard.stories.tsx
+++ b/src/widgets/award/ui/AwardCard.stories.tsx
@@ -8,8 +8,8 @@ const meta = {
   title: 'Widgets/Award/Card',
   component: AwardCard,
   args: {
-    onClick: fn(),
     award: AWARD_LIST[0],
+    onClick: fn(),
   },
   parameters: {
     layout: 'centered',

--- a/src/widgets/award/ui/Popup.stories.tsx
+++ b/src/widgets/award/ui/Popup.stories.tsx
@@ -1,22 +1,17 @@
+import { useAwardStore } from '@features/award';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { fn } from 'storybook/test';
 
 import { AwardPopup } from './Popup';
 
 const meta = {
   title: 'Widgets/Award/Popup',
   component: AwardPopup,
-  args: {
-    onClose: fn(),
-    awardId: 0,
-    awardTitle: '수상 이미지',
-  },
   parameters: {
     layout: 'fullscreen',
     docs: {
       description: {
         component:
-          '수상 카드 클릭 시 열리는 팝업. 해당 수상 이미지를 전체화면 오버레이로 표시하며, 닫기 버튼 또는 배경 클릭으로 닫힙니다.',
+          '수상 카드 클릭 시 열리는 팝업. Zustand 스토어의 selectedId가 null이 아닌 경우에만 렌더링됩니다. 수상 이미지를 전체화면 오버레이로 표시하며, 닫기 버튼 또는 배경 클릭으로 닫힙니다.',
       },
     },
   },
@@ -27,6 +22,12 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   name: '팝업 열림',
+  decorators: [
+    (Story) => {
+      useAwardStore.setState({ selectedId: 0 });
+      return <Story />;
+    },
+  ],
   parameters: {
     docs: {
       description: {

--- a/src/widgets/award/ui/Viewport.stories.tsx
+++ b/src/widgets/award/ui/Viewport.stories.tsx
@@ -1,24 +1,23 @@
-import { AWARD_LIST } from '@entities/award';
+import { useAwardStore } from '@features/award';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { fn } from 'storybook/test';
 
 import { Viewport } from './Viewport';
 
 const meta = {
   title: 'Widgets/Award/Viewport',
   component: Viewport,
-  args: {
-    filteredList: AWARD_LIST,
-    safePage: 0,
-    onCardClick: fn(),
-    setCurrentPage: fn(),
-  },
+  decorators: [
+    (Story) => {
+      useAwardStore.setState({ activeYear: '전체', currentPage: 0 });
+      return <Story />;
+    },
+  ],
   parameters: {
     layout: 'fullscreen',
     docs: {
       description: {
         component:
-          '수상 카드를 페이지 단위로 슬라이드하는 뷰포트 컴포넌트. itemsPerPage에 따라 2×2 / 3×2 / 5×2 그리드로 전환됩니다.',
+          '수상 카드를 페이지 단위로 슬라이드하는 뷰포트 컴포넌트. itemsPerPage에 따라 2×2 / 3×2 / 5×2 그리드로 전환됩니다. Zustand 스토어의 activeYear와 currentPage를 사용합니다.',
       },
     },
   },
@@ -29,10 +28,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   name: '(5×2, 10개/페이지)',
-  args: {
-    itemsPerPage: 10,
-    totalPages: Math.ceil(AWARD_LIST.length / 10),
-  },
+  args: { itemsPerPage: 10 },
   globals: {
     viewport: { value: 'desktop' },
   },
@@ -47,10 +43,10 @@ export const Default: Story = {
 
 export const Tablet: Story = {
   name: '(3×2, 6개/페이지)',
+  args: { itemsPerPage: 6 },
   globals: {
     viewport: { value: 'tablet' },
   },
-  args: { itemsPerPage: 6, totalPages: Math.ceil(AWARD_LIST.length / 6) },
   parameters: {
     docs: {
       description: {
@@ -62,10 +58,10 @@ export const Tablet: Story = {
 
 export const Mobile: Story = {
   name: '(2×2, 4개/페이지)',
+  args: { itemsPerPage: 4 },
   globals: {
     viewport: { value: 'mobile' },
   },
-  args: { itemsPerPage: 4, totalPages: Math.ceil(AWARD_LIST.length / 4) },
   parameters: {
     docs: {
       description: {

--- a/src/widgets/award/ui/Viewport.tsx
+++ b/src/widgets/award/ui/Viewport.tsx
@@ -10,13 +10,17 @@ import { motion } from 'framer-motion';
 import '../styles/Viewport.css';
 import { AwardCard } from './AwardCard';
 
-export function Viewport() {
+export function Viewport({
+  itemsPerPage: itemsPerPageProp,
+}: {
+  itemsPerPage?: number;
+}) {
   const activeYear = useAwardStore((s) => s.activeYear);
   const currentPage = useAwardStore((s) => s.currentPage);
   const setCurrentPage = useAwardStore((s) => s.setCurrentPage);
   const setSelectedId = useAwardStore((s) => s.setSelectedId);
   const breakpoint = useBreakpoint();
-  const itemsPerPage = getItemsPerPage(breakpoint);
+  const itemsPerPage = itemsPerPageProp ?? getItemsPerPage(breakpoint);
 
   const filteredList = useMemo(() => {
     const list =

--- a/src/widgets/history/ui/Category.stories.tsx
+++ b/src/widgets/history/ui/Category.stories.tsx
@@ -17,6 +17,7 @@ const meta = {
         component:
           'History 섹션의 카테고리 탭 네비게이션. Zustand 스토어의 tabActiveItem에 따라 활성 탭이 결정됩니다.',
       },
+      story: { inline: false },
     },
   },
   decorators: [

--- a/src/widgets/history/ui/book/BookPageOuterShadow.stories.tsx
+++ b/src/widgets/history/ui/book/BookPageOuterShadow.stories.tsx
@@ -31,7 +31,7 @@ const meta = {
   },
   decorators: [
     (Story, ctx) => {
-      const side = (ctx.args.side as 'left' | 'right') ?? 'left';
+      const side = ctx.args.side ?? 'left';
       return (
         <div
           className={`history__book-page-${side}`}


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- #48 

### Storybook 스토리 품질 개선

- Award Pagination 스토리에 `totalPages` 인자가 누락되어 있어 실제 동작과 괴리가 있었음
- Viewport 스토리의 반응형 시나리오(desktop/tablet/mobile)를 명확하게 정리함
- YearCategory·Popup 스토리의 Zustand 초기 상태 설정 방식 통일
- BookPageOuterShadow 스토리의 lint 오류 수정

### 핵심 변화

#### 변경 전

- `Pagination` 스토리에 `totalPages` prop이 없어 실제 컴포넌트 시그니처와 불일치
- `Viewport` 스토리에서 반응형 breakpoint별 시나리오가 혼재
- Zustand 스토어 초기화 방식이 스토리마다 다르게 작성됨

#### 변경 후

- `totalPages` arg를 명시하여 스토리가 컴포넌트 실제 props를 정확히 반영
- `Viewport` 스토리를 desktop / tablet / mobile 3가지로 분리하고 `globals.viewport` 지정
- `decorators` 내 `useAwardStore.setState` 패턴으로 통일

# 📋 작업 내용

- `src/features/award/ui/Pagination.stories.tsx` — `totalPages` 인자 추가, 스토리 시나리오 3개(기본/중간/마지막 페이지)로 정리
- `src/features/award/ui/YearCategory.stories.tsx` — Zustand 초기 상태 설정 방식 통일
- `src/widgets/award/ui/Viewport.stories.tsx` — 반응형 breakpoint별 스토리 분리
- `src/widgets/award/ui/Popup.stories.tsx` — 스토리 구조 개선
- `src/widgets/history/ui/Category.stories.tsx` — 스토리 누락 항목 보완
- `src/widgets/history/ui/book/BookPageOuterShadow.stories.tsx` — lint 오류 수정