### PR TITLE
🔨 refactor: Home 컴포넌트 리팩토링

### DIFF
--- a/src/pages/home/Home.test.tsx
+++ b/src/pages/home/Home.test.tsx
@@ -126,4 +126,61 @@ describe('Home', () => {
       expect(smoothScrollTo).not.toHaveBeenCalled();
     });
   });
+
+  describe('DevWidgetView (VITE_DEV_WIDGET 설정 시)', () => {
+    beforeEach(() => {
+      vi.useRealTimers();
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    });
+
+    it('유효한 위젯(hero)이면 Header와 해당 위젯이 렌더링된다', async () => {
+      vi.stubEnv('VITE_DEV_WIDGET', 'hero');
+      const { Home: DynamicHome } = await import('./Home');
+      await act(async () => {
+        render(
+          <MemoryRouter>
+            <DynamicHome />
+          </MemoryRouter>,
+        );
+        await Promise.resolve();
+      });
+      expect(screen.getByTestId('header')).toBeInTheDocument();
+      expect(screen.getByTestId('hero')).toBeInTheDocument();
+    });
+
+    it('footer 위젯이면 Header 없이 footer만 렌더링된다', async () => {
+      vi.stubEnv('VITE_DEV_WIDGET', 'footer');
+      const { Home: DynamicHome } = await import('./Home');
+      await act(async () => {
+        render(
+          <MemoryRouter>
+            <DynamicHome />
+          </MemoryRouter>,
+        );
+        await Promise.resolve();
+      });
+      expect(screen.queryByTestId('header')).not.toBeInTheDocument();
+      expect(screen.getByTestId('footer')).toBeInTheDocument();
+    });
+
+    it('유효하지 않은 위젯이면 에러 메시지가 렌더링된다', async () => {
+      vi.stubEnv('VITE_DEV_WIDGET', 'nonexistent');
+      const { Home: DynamicHome } = await import('./Home');
+      await act(async () => {
+        render(
+          <MemoryRouter>
+            <DynamicHome />
+          </MemoryRouter>,
+        );
+        await Promise.resolve();
+      });
+      expect(
+        screen.getByText(/위젯 "nonexistent"을 찾을 수 없습니다\./),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -8,28 +8,23 @@ import { Vision } from '@widgets/vision';
 
 import './styles/Home.css';
 
-const History = lazy(() =>
-  import('@widgets/history').then((m) => ({ default: m.History })),
-);
-const Award = lazy(() =>
-  import('@widgets/award').then((m) => ({ default: m.Award })),
-);
-const Patent = lazy(() =>
-  import('@widgets/patent').then((m) => ({ default: m.Patent })),
-);
-const Map = lazy(() =>
-  import('@widgets/map').then((m) => ({ default: m.Map })),
-);
-const Footer = lazy(() =>
-  import('@widgets/footer').then((m) => ({ default: m.Footer })),
-);
+const widgetLoaders = {
+  History: () =>
+    import('@widgets/history').then((m) => ({ default: m.History })),
+  Award: () => import('@widgets/award').then((m) => ({ default: m.Award })),
+  Patent: () => import('@widgets/patent').then((m) => ({ default: m.Patent })),
+  Map: () => import('@widgets/map').then((m) => ({ default: m.Map })),
+  Footer: () => import('@widgets/footer').then((m) => ({ default: m.Footer })),
+};
+
+const History = lazy(widgetLoaders.History);
+const Award = lazy(widgetLoaders.Award);
+const Patent = lazy(widgetLoaders.Patent);
+const Map = lazy(widgetLoaders.Map);
+const Footer = lazy(widgetLoaders.Footer);
 
 function prefetchLazyWidgets() {
-  void import('@widgets/history');
-  void import('@widgets/award');
-  void import('@widgets/patent');
-  void import('@widgets/map');
-  void import('@widgets/footer');
+  Object.values(widgetLoaders).forEach((load) => void load());
 }
 
 const DEV_WIDGET = import.meta.env.VITE_DEV_WIDGET;
@@ -46,6 +41,47 @@ const DEV_WIDGET_MAP: Record<string, ReactNode> = {
   map: <Map />,
   footer: <Footer />,
 };
+
+function DevWidgetView({ name }: { name: string }) {
+  const widget = DEV_WIDGET_MAP[name];
+  if (!widget) {
+    return (
+      <div
+        style={{
+          padding: '2rem',
+          fontFamily: 'monospace',
+          color: '#fff',
+          background: '#111',
+          minHeight: '100vh',
+        }}
+      >
+        <p>⚠️ 위젯 &quot;{name}&quot;을 찾을 수 없습니다.</p>
+        <p>등록된 위젯: {Object.keys(DEV_WIDGET_MAP).join(', ')}</p>
+        <p>DEV_WIDGET_MAP에 등록 후 다시 실행하세요.</p>
+      </div>
+    );
+  }
+  return (
+    <>
+      {name !== 'footer' ? <Header /> : null}
+      <Suspense fallback={null}>{widget}</Suspense>
+    </>
+  );
+}
+
+function LazySection({
+  name,
+  children,
+}: {
+  name: string;
+  children: ReactNode;
+}) {
+  return (
+    <Suspense fallback={<div className={`home__fallback--${name}`} />}>
+      {children}
+    </Suspense>
+  );
+}
 
 export function Home() {
   const location = useLocation();
@@ -77,30 +113,7 @@ export function Home() {
   }, []);
 
   if (DEV_WIDGET) {
-    const widget = DEV_WIDGET_MAP[DEV_WIDGET];
-    if (!widget) {
-      return (
-        <div
-          style={{
-            padding: '2rem',
-            fontFamily: 'monospace',
-            color: '#fff',
-            background: '#111',
-            minHeight: '100vh',
-          }}
-        >
-          <p>⚠️ 위젯 &quot;{DEV_WIDGET}&quot;을 찾을 수 없습니다.</p>
-          <p>등록된 위젯: {Object.keys(DEV_WIDGET_MAP).join(', ')}</p>
-          <p>DEV_WIDGET_MAP에 등록 후 다시 실행하세요.</p>
-        </div>
-      );
-    }
-    return (
-      <>
-        {DEV_WIDGET !== 'footer' ? <Header /> : null}
-        <Suspense fallback={null}>{widget}</Suspense>
-      </>
-    );
+    return <DevWidgetView name={DEV_WIDGET} />;
   }
 
   if (isStaging) {
@@ -117,21 +130,21 @@ export function Home() {
         <Hero showScrollArrow={isProduction} />
         <Vision />
         <div ref={prefetchTriggerRef} aria-hidden='true' />
-        <Suspense fallback={<div className='home__fallback--history' />}>
+        <LazySection name='history'>
           <History />
-        </Suspense>
-        <Suspense fallback={<div className='home__fallback--award' />}>
+        </LazySection>
+        <LazySection name='award'>
           <Award />
-        </Suspense>
-        <Suspense fallback={<div className='home__fallback--patent' />}>
+        </LazySection>
+        <LazySection name='patent'>
           <Patent />
-        </Suspense>
-        <Suspense fallback={<div className='home__fallback--map' />}>
+        </LazySection>
+        <LazySection name='map'>
           <Map />
-        </Suspense>
-        <Suspense fallback={<div className='home__fallback--footer' />}>
+        </LazySection>
+        <LazySection name='footer'>
           <Footer />
-        </Suspense>
+        </LazySection>
       </main>
     </>
   );


### PR DESCRIPTION
<!--
```
- PR이 승인되면 해당 브랜치 삭제하기
```
-->

# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

관련 이슈 없음

### 반복 패턴 컴포넌트화

- `Home.tsx` 내에 인라인으로 작성된 로직을 별도 컴포넌트로 분리하여 가독성과 유지보수성을 개선했습니다.
- 변경 전에는 5개의 `lazy()` 선언과 `prefetchLazyWidgets`의 5개 `void import()` 호출이 각각 독립적으로 나열되어 있었습니다.

### 핵심 변화

#### 변경 전

- `lazy()` 선언 5개가 각각 독립적으로 분산
- `prefetchLazyWidgets`에서 `void import()`를 5번 반복 호출
- DEV_WIDGET 분기 로직이 `Home` 컴포넌트 내에 인라인으로 30줄 이상 차지
- Suspense fallback 패턴이 5번 반복 작성

#### 변경 후

- `widgetLoaders` 객체로 로더 함수를 중앙화 → `lazy(widgetLoaders.X)` 형태로 단순화
- `prefetchLazyWidgets`를 `Object.values(widgetLoaders).forEach(load => void load())`로 단순화
- `DevWidgetView` 컴포넌트로 DEV_WIDGET 분기 UI 추출
- `LazySection` 컴포넌트로 반복되는 `<Suspense fallback={<div className="home__fallback--{name}" />}>` 패턴 추출

# 📋 작업 내용

- `widgetLoaders` 객체: lazy 로더 함수를 한 곳에서 관리하도록 중앙화
- `DevWidgetView` 컴포넌트: 개발 환경 단일 위젯 미리보기 UI 분리
- `LazySection` 컴포넌트: Suspense + fallback 반복 패턴을 재사용 가능한 컴포넌트로 추출
- 기능 변경 없이 구조만 개선 (순수 리팩토링)