### PR TITLE
👹 fix: 책 애니메이션 롤백

### DIFF
--- a/src/app/styles/index.css
+++ b/src/app/styles/index.css
@@ -167,18 +167,6 @@ a,
   outline-offset: 2px;
 }
 
-/* ─── Reduced Motion ─────────────────────────────────────────────────────── */
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
-}
-
 /* ─── Accessibility ──────────────────────────────────────────────────────── */
 .sr-only {
   position: absolute;


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #240

### 문제 원인

`@media (prefers-reduced-motion: reduce)` 전역 미디어 쿼리가 `animation-duration: 0.01ms !important`를 모든 요소에 적용하고 있었습니다. 이로 인해 책 넘기기(book-flip) 애니메이션이 OS 설정에 따라 완전히 비활성화되는 문제가 발생했습니다.

### 핵심 변화

#### 변경 전

`src/app/styles/index.css`에 `prefers-reduced-motion` 미디어 쿼리 존재 → 책 애니메이션 동작 불가

#### 변경 후

해당 전역 `prefers-reduced-motion` 블록 제거 → 책 애니메이션 정상 동작

# 📋 작업 내용
- index.css에 reduced motion 미디어 쿼리 제거


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 글로벌 애니메이션 및 스크롤 동작 관련 스타일링 규칙이 제거되었습니다. 이제 애니메이션과 전환 효과가 정상 속도로 재생되며 스크롤 동작이 변경됩니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Induel-E-H/web-FE/pull/241)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->