### PR TITLE
✨ feat: Google Analytics 이벤트 수집 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "framer-motion": "^12.38.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "react-ga4": "^3.0.1",
         "react-icons": "^5.6.0",
         "react-router-dom": "^7.14.2",
         "three": "^0.184.0",
@@ -10937,6 +10938,12 @@
       "peerDependencies": {
         "react": "^19.2.5"
       }
+    },
+    "node_modules/react-ga4": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-3.0.1.tgz",
+      "integrity": "sha512-GyCc01bSheWXjzGDyHsXMOqk/SP5Cf/JrcJTg4hcpKx4eeSwaJKpJUc+ipF4ffLTZkmabmf3ZGBv4OKHTXNXyA==",
+      "license": "MIT"
     },
     "node_modules/react-icons": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "framer-motion": "^12.38.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-ga4": "^3.0.1",
     "react-icons": "^5.6.0",
     "react-router-dom": "^7.14.2",
     "three": "^0.184.0",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,11 +1,17 @@
+import { useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
 import { Home } from '@pages/home';
 import { PrivacyPolicy } from '@pages/privacy-policy';
-import { useGoogleAnalytics } from '@shared/lib/analytics';
+import { trackBrowserLimited, useGoogleAnalytics } from '@shared/lib/analytics';
+import { getBrowserSupport } from '@shared/lib/browserCompat';
 
 function App() {
   useGoogleAnalytics();
+
+  useEffect(() => {
+    if (getBrowserSupport() === 'limited') trackBrowserLimited();
+  }, []);
 
   return (
     <Routes>

--- a/src/features/award/ui/YearCategory.tsx
+++ b/src/features/award/ui/YearCategory.tsx
@@ -1,3 +1,5 @@
+import { trackAwardYearFilter } from '@shared/lib/analytics';
+
 import { YEAR_LIST } from '../model/constant';
 import { useAwardStore } from '../model/useAwardStore';
 import '../styles/YearCategory.css';
@@ -16,7 +18,10 @@ export function YearCategory() {
             key={year}
             aria-current={isActive ? 'true' : undefined}
             className={isActive ? 'award__year_category--active' : ''}
-            onClick={() => handleYearChange(year)}
+            onClick={() => {
+              trackAwardYearFilter(year);
+              handleYearChange(year);
+            }}
           >
             {year}
           </button>

--- a/src/pages/unsupported-browser/UnsupportedBrowser.test.tsx
+++ b/src/pages/unsupported-browser/UnsupportedBrowser.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { UnsupportedBrowser } from './UnsupportedBrowser';
+
+vi.mock('@shared/lib/analytics', () => ({
+  initGA: vi.fn(),
+  trackBrowserUnsupported: vi.fn(),
+}));
 
 describe('UnsupportedBrowser', () => {
   describe('헤딩 및 안내 메시지', () => {

--- a/src/pages/unsupported-browser/UnsupportedBrowser.tsx
+++ b/src/pages/unsupported-browser/UnsupportedBrowser.tsx
@@ -1,6 +1,14 @@
+import { useEffect } from 'react';
+
+import { initGA, trackBrowserUnsupported } from '@shared/lib/analytics';
+
 import './styles/UnsupportedBrowser.css';
 
 export function UnsupportedBrowser() {
+  useEffect(() => {
+    initGA();
+    trackBrowserUnsupported();
+  }, []);
   return (
     <div className='unsupported-browser'>
       <div className='unsupported-browser__content'>

--- a/src/shared/lib/analytics/events.ts
+++ b/src/shared/lib/analytics/events.ts
@@ -1,0 +1,40 @@
+import ReactGA from 'react-ga4';
+
+export const trackNavLogoClick = () => ReactGA.event('nav_logo_click');
+
+export const trackNavMenuClick = (section: string) =>
+  ReactGA.event('nav_menu_click', { section });
+
+export const trackAwardYearFilter = (year: string | number) =>
+  ReactGA.event('award_year_filter', { year: String(year) });
+
+export const trackAwardCardOpen = (title: string) =>
+  ReactGA.event('award_card_open', { title });
+
+export const trackPatentCardOpen = (title: string) =>
+  ReactGA.event('patent_card_open', { title });
+
+export const trackHistoryCoverOpen = (cover: 'front' | 'back') =>
+  ReactGA.event('history_cover_open', { cover });
+
+export const trackHistoryPageTurn = (direction: 'forward' | 'backward') =>
+  ReactGA.event('history_page_turn', { direction });
+
+export const trackHistoryCategoryChange = (category: string) =>
+  ReactGA.event('history_category_change', { category });
+
+export const trackHistoryArtworkGalleryOpen = (title: string) =>
+  ReactGA.event('history_artwork_gallery_open', { title });
+
+export const trackMapLoadSuccess = () => ReactGA.event('map_load_success');
+
+export const trackMapLoadFailure = () => ReactGA.event('map_load_failure');
+
+export const trackPrivacyPolicyClick = () =>
+  ReactGA.event('privacy_policy_click');
+
+export const trackBrowserUnsupported = () =>
+  ReactGA.event('browser_unsupported', { user_agent: navigator.userAgent });
+
+export const trackBrowserLimited = () =>
+  ReactGA.event('browser_limited', { user_agent: navigator.userAgent });

--- a/src/shared/lib/analytics/index.ts
+++ b/src/shared/lib/analytics/index.ts
@@ -1,1 +1,2 @@
-export { useGoogleAnalytics } from './useGoogleAnalytics';
+export { useGoogleAnalytics, initGA } from './useGoogleAnalytics';
+export * from './events';

--- a/src/shared/lib/analytics/useGoogleAnalytics.test.tsx
+++ b/src/shared/lib/analytics/useGoogleAnalytics.test.tsx
@@ -1,79 +1,58 @@
+import ReactGA from 'react-ga4';
+import { MemoryRouter } from 'react-router-dom';
+
 import { render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useGoogleAnalytics } from './useGoogleAnalytics';
 
-const GA_ID = 'G-JMQZ9VKYZ6';
+vi.mock('react-ga4', () => ({
+  default: { initialize: vi.fn(), send: vi.fn() },
+}));
 
 function TestComponent() {
   useGoogleAnalytics();
   return null;
 }
 
+function renderInRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
 describe('useGoogleAnalytics', () => {
-  let mockScript: { src: string; async: boolean };
-  let appendChildSpy: ReturnType<typeof vi.spyOn>;
-  let originalCreateElement: typeof document.createElement;
-
   beforeEach(() => {
-    originalCreateElement = document.createElement.bind(document);
-    mockScript = { src: '', async: false };
-
-    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
-      if (tag === 'script') return mockScript as unknown as HTMLScriptElement;
-      return originalCreateElement(tag);
-    });
-    appendChildSpy = vi
-      .spyOn(document.head, 'appendChild')
-      .mockImplementation((node) => node);
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    delete (window as Partial<Window & typeof globalThis>).dataLayer;
-    delete (window as Partial<Window & typeof globalThis>).gtag;
   });
 
-  describe('마운트 시 script 태그 추가', () => {
-    it('document.head.appendChild가 script 태그로 호출된다', () => {
-      render(<TestComponent />);
-      expect(appendChildSpy).toHaveBeenCalledWith(mockScript);
-    });
-
-    it('script src가 googletagmanager.com gtag/js URL 형식이다', () => {
-      render(<TestComponent />);
-      expect(mockScript.src).toContain(
-        'https://www.googletagmanager.com/gtag/js',
-      );
-    });
-
-    it('script src에 GA ID가 포함된다', () => {
-      render(<TestComponent />);
-      expect(mockScript.src).toContain(GA_ID);
-    });
-
-    it('script의 async 속성이 true이다', () => {
-      render(<TestComponent />);
-      expect(mockScript.async).toBe(true);
-    });
+  it('마운트 시 ReactGA.initialize가 호출된다', () => {
+    renderInRouter(<TestComponent />);
+    expect(ReactGA.initialize).toHaveBeenCalledOnce();
   });
 
-  describe('window 전역 설정', () => {
-    it('window.dataLayer가 배열로 초기화된다', () => {
-      render(<TestComponent />);
-      expect(Array.isArray(window.dataLayer)).toBe(true);
-    });
+  it('올바른 GA ID로 초기화된다', () => {
+    renderInRouter(<TestComponent />);
+    expect(ReactGA.initialize).toHaveBeenCalledWith('G-JMQZ9VKYZ6');
+  });
 
-    it('window.gtag가 함수로 설정된다', () => {
-      render(<TestComponent />);
-      expect(typeof window.gtag).toBe('function');
-    });
+  it('리렌더링 시 initialize가 중복 호출되지 않는다', () => {
+    const { rerender } = renderInRouter(<TestComponent />);
+    rerender(
+      <MemoryRouter>
+        <TestComponent />
+      </MemoryRouter>,
+    );
+    expect(ReactGA.initialize).toHaveBeenCalledOnce();
+  });
 
-    it('window.gtag 호출 시 dataLayer에 항목이 추가된다', () => {
-      render(<TestComponent />);
-      const prevLength = window.dataLayer.length;
-      window.gtag('event', 'test_event');
-      expect(window.dataLayer.length).toBeGreaterThan(prevLength);
+  it('마운트 시 pageview 이벤트가 전송된다', () => {
+    renderInRouter(<TestComponent />);
+    expect(ReactGA.send).toHaveBeenCalledWith({
+      hitType: 'pageview',
+      page: '/',
     });
   });
 });

--- a/src/shared/lib/analytics/useGoogleAnalytics.ts
+++ b/src/shared/lib/analytics/useGoogleAnalytics.ts
@@ -1,26 +1,21 @@
 import { useEffect } from 'react';
+import ReactGA from 'react-ga4';
+import { useLocation } from 'react-router-dom';
 
-declare global {
-  interface Window {
-    dataLayer: unknown[];
-    gtag: (...args: unknown[]) => void;
-  }
+export const GA_ID = 'G-JMQZ9VKYZ6';
+
+export function initGA() {
+  ReactGA.initialize(GA_ID);
 }
 
-const GA_ID = 'G-JMQZ9VKYZ6';
-
 export function useGoogleAnalytics() {
-  useEffect(() => {
-    const script = document.createElement('script');
-    script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
-    script.async = true;
-    document.head.appendChild(script);
+  const location = useLocation();
 
-    window.dataLayer = window.dataLayer || [];
-    window.gtag = function (...args: unknown[]) {
-      window.dataLayer.push(args);
-    };
-    window.gtag('js', new Date());
-    window.gtag('config', GA_ID);
+  useEffect(() => {
+    initGA();
   }, []);
+
+  useEffect(() => {
+    ReactGA.send({ hitType: 'pageview', page: location.pathname });
+  }, [location.pathname]);
 }

--- a/src/widgets/award/ui/Viewport.tsx
+++ b/src/widgets/award/ui/Viewport.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { AWARD_LIST } from '@entities/award';
 import { useAwardStore, YEAR_ALL } from '@features/award';
 import { getItemsPerPage } from '@features/award';
+import { trackAwardCardOpen } from '@shared/lib/analytics';
 import { useBreakpoint } from '@shared/lib/breakpoint';
 import { useSlideGesture } from '@shared/lib/useSlideGesture';
 import { motion } from 'framer-motion';
@@ -73,7 +74,10 @@ export function Viewport({
               <AwardCard
                 key={award.id}
                 award={award}
-                onClick={() => setSelectedId(award.id)}
+                onClick={() => {
+                  trackAwardCardOpen(award.title);
+                  setSelectedId(award.id);
+                }}
               />
             ))}
           </div>

--- a/src/widgets/footer/ui/Footer.tsx
+++ b/src/widgets/footer/ui/Footer.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { induelIcon } from '@shared/assets';
 import { COMPANY } from '@shared/constant';
+import { trackPrivacyPolicyClick } from '@shared/lib/analytics';
 
 import '../styles/Footer.css';
 
@@ -21,7 +22,12 @@ export function Footer() {
           </div>
         </div>
         <div className='footer__information'>
-          <button onClick={() => void navigate('/privacy_policy')}>
+          <button
+            onClick={() => {
+              trackPrivacyPolicyClick();
+              void navigate('/privacy_policy');
+            }}
+          >
             <b>개인정보처리방침</b>
           </button>
         </div>

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -6,6 +6,7 @@ import { useHeaderVisibility } from '@features/header';
 import { useIsHero } from '@features/header';
 import { induelIcon } from '@shared/assets';
 import { COMPANY } from '@shared/constant';
+import { trackNavLogoClick, trackNavMenuClick } from '@shared/lib/analytics';
 import { smoothScrollTo } from '@shared/lib/scroll';
 import { AnimatePresence, motion } from 'framer-motion';
 
@@ -43,6 +44,7 @@ export function Header({ onNavClick }: HeaderProps = {}) {
   }
 
   function handleLogoClick() {
+    trackNavLogoClick();
     if (!isHome) {
       void navigate('/');
       return;
@@ -51,7 +53,13 @@ export function Header({ onNavClick }: HeaderProps = {}) {
   }
 
   const navItems = NAV_ITEMS.map(({ label, selector }) => (
-    <button key={label} onClick={() => scrollTo(selector)}>
+    <button
+      key={label}
+      onClick={() => {
+        trackNavMenuClick(label);
+        scrollTo(selector);
+      }}
+    >
       {label}
     </button>
   ));

--- a/src/widgets/history/ui/History.tsx
+++ b/src/widgets/history/ui/History.tsx
@@ -6,6 +6,11 @@ import type { IndexItem } from '@features/history';
 import { useBookCoverState } from '@features/history';
 import { useBookNavigation } from '@features/history';
 import { BOOK_STATE } from '@features/history';
+import {
+  trackHistoryCategoryChange,
+  trackHistoryCoverOpen,
+  trackHistoryPageTurn,
+} from '@shared/lib/analytics';
 import { useBreakpoint } from '@shared/lib/breakpoint';
 
 import '../styles/History.css';
@@ -175,12 +180,14 @@ export function History() {
 
   function handleFrontCoverClick() {
     if (isAnimatingRef.current) return;
+    trackHistoryCoverOpen('front');
     openingFront();
     startFlipAnimation('forward', onOpened);
   }
 
   function handleBackCoverClick() {
     if (isAnimatingRef.current) return;
+    trackHistoryCoverOpen('back');
     openingBack();
     startFlipAnimation('backward', onOpened);
   }
@@ -193,6 +200,7 @@ export function History() {
       }
       return;
     }
+    trackHistoryPageTurn('backward');
     beginContinuousFlip(PAGE_SIDE.LEFT);
   }
 
@@ -204,10 +212,12 @@ export function History() {
       }
       return;
     }
+    trackHistoryPageTurn('forward');
     beginContinuousFlip(PAGE_SIDE.RIGHT);
   }
 
   function handleNavigateToCategory(item: IndexItem) {
+    trackHistoryCategoryChange(String(item));
     if (bookState === 'cover-front') {
       if (isAnimatingRef.current) return;
       setPendingCategory(item);

--- a/src/widgets/history/ui/book/content_container/Content.tsx
+++ b/src/widgets/history/ui/book/content_container/Content.tsx
@@ -9,6 +9,7 @@ import {
 } from '@entities/history';
 import { getArtworkIndex, preloadContentImages } from '@features/history';
 import type { PageSide } from '@features/history';
+import { trackHistoryArtworkGalleryOpen } from '@shared/lib/analytics';
 import { AnimatePresence } from 'framer-motion';
 
 import '../../../styles/book/content_container/Content.css';
@@ -89,6 +90,7 @@ function ContentItem({
   }, [imageSrc]);
 
   async function openImageGallery() {
+    trackHistoryArtworkGalleryOpen(item.title);
     const images = await getAllContentImages(index);
     setContentImages(images);
     setShowPopup(true);

--- a/src/widgets/map/ui/Map.tsx
+++ b/src/widgets/map/ui/Map.tsx
@@ -2,6 +2,10 @@ import { useEffect, useRef, useState } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import { COMPANY } from '@shared/constant';
+import {
+  trackMapLoadFailure,
+  trackMapLoadSuccess,
+} from '@shared/lib/analytics';
 
 import { MAP_STATE, type MapState } from '../model/constant';
 import { makeMap } from '../model/map';
@@ -48,8 +52,12 @@ export function Map() {
     const key = import.meta.env.VITE_NAVER_MAP_API_KEY as string | undefined;
     if (!key) return;
 
-    const handleLoad = () =>
-      setMapState(isNaverAvailable() ? MAP_STATE.READY : MAP_STATE.FALLBACK);
+    const handleLoad = () => {
+      const ready = isNaverAvailable();
+      setMapState(ready ? MAP_STATE.READY : MAP_STATE.FALLBACK);
+      if (ready) trackMapLoadSuccess();
+      else trackMapLoadFailure();
+    };
 
     const existing = document.querySelector(
       'script[src*="oapi.map.naver.com"]',
@@ -69,7 +77,10 @@ export function Map() {
     script.src = `https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${key}`;
     script.async = true;
     script.onload = handleLoad;
-    script.onerror = () => setMapState(MAP_STATE.FALLBACK);
+    script.onerror = () => {
+      setMapState(MAP_STATE.FALLBACK);
+      trackMapLoadFailure();
+    };
     document.head.appendChild(script);
 
     return () => {

--- a/src/widgets/patent/ui/ValidContent.tsx
+++ b/src/widgets/patent/ui/ValidContent.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 import { FaRegCheckCircle } from 'react-icons/fa';
 
 import { getPatentImage, PATENT_VALID_LIST } from '@entities/patent';
+import { trackPatentCardOpen } from '@shared/lib/analytics';
 import { usePreloadOnVisible } from '@shared/lib/preload/usePreloadOnVisible';
 import { AnimatePresence } from 'framer-motion';
 
@@ -33,7 +34,13 @@ export function PatentValidContent() {
       <ul className='patent__content__item__list'>
         {PATENT_VALID_LIST.map((patent, index) => (
           <li key={patent.serialNumber}>
-            <PatentCard patent={patent} onClick={() => setSelectedId(index)} />
+            <PatentCard
+              patent={patent}
+              onClick={() => {
+                trackPatentCardOpen(patent.title);
+                setSelectedId(index);
+              }}
+            />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

- close #26 

### GA 수집 불가 원인 수정 및 이벤트 구현

- 4월 27일 GA 코드를 `index.html`에서 `useEffect`로 이전한 후 수집이 되지 않는 문제 발생
- 원인: `window.gtag` 구현 시 `...args` rest parameter로 일반 배열을 push → GA4가 `IArguments` 객체를 기대하여 명령을 무시
- 해결: `react-ga4` 라이브러리 도입으로 내부 구현 위임, SPA 라우트 변경 시 `page_view` 자동 전송

### 핵심 변화

#### 변경 전

- `index.html` 기반 GA 스크립트 또는 수동 `gtag` 함수 구현
- 단순 초기화만 존재, 사용자 행동 이벤트 없음
- `unsupported` 브라우저 방문 미추적

#### 변경 후

- `react-ga4` 라이브러리 기반 초기화
- `useLocation`으로 라우트 변경 시 자동 `page_view` 전송
- `unsupported` / `limited` 브라우저 감지 및 이벤트 수집
- 사용자 인터랙션 이벤트 12종 추가

# 📋 작업 내용

### GA 초기화 개선
- `react-ga4` 라이브러리 설치 및 적용
- `initGA()` 함수 분리 → `UnsupportedBrowser` 페이지에서도 독립 초기화 가능
- SPA 라우트 변경(`/` ↔ `/privacy_policy`) 시 `page_view` 이벤트 자동 전송

### 브라우저 호환성 이벤트
- `browser_unsupported` — Chrome 79 이하 방문 시 (`user_agent` 포함)
- `browser_limited` — Chrome 80–89 방문 시 (`user_agent` 포함)

### 사용자 인터랙션 이벤트 (12종)

| 이벤트 | 파라미터 | 위치 |
|---|---|---|
| `nav_logo_click` | — | Header 로고 |
| `nav_menu_click` | `section` | Header 네비게이션 |
| `award_year_filter` | `year` | Award 연도 필터 |
| `award_card_open` | `title` | Award 카드 팝업 |
| `patent_card_open` | `title` | Patent 카드 팝업 |
| `history_cover_open` | `cover: front\|back` | History 표지 클릭 |
| `history_page_turn` | `direction: forward\|backward` | History 페이지 넘김 |
| `history_category_change` | `category` | History 카테고리 탭 |
| `history_artwork_gallery_open` | `title` | History 작품 이미지 팝업 |
| `map_load_success` | — | Naver Map 로드 성공 |
| `map_load_failure` | — | Map 로드 실패 (fallback) |
| `privacy_policy_click` | — | Footer 개인정보처리방침 |

모든 이벤트 정의는 `src/shared/lib/analytics/events.ts` 한 곳에서 관리합니다.

# 📷 스크린 샷 (선택 사항)

해당 없음