### PR TITLE
⚡️ perf: 팝업·컨텐츠 이미지 lazy 제거 및 프리로드 범위 확장

### DIFF
--- a/src/features/history/model/helpers.test.ts
+++ b/src/features/history/model/helpers.test.ts
@@ -49,23 +49,27 @@ describe('preloadContentImages', () => {
     vi.mocked(preloadImages).mockClear();
   });
 
-  it('pageIndex=2이면 인접 페이지(1, 3)의 4개 이미지 URL을 preload한다', () => {
+  it('pageIndex=2이면 현재(2)와 인접 페이지(1, 3)의 6개 이미지 URL을 preload한다', () => {
     preloadContentImages(2);
     expect(vi.mocked(preloadImages)).toHaveBeenCalledOnce();
     const arg = vi.mocked(preloadImages).mock.calls[0][0];
-    // adjacent: pageIndex 3 → idx 6, 7 / pageIndex 1 → idx 2, 3
-    expect(arg).toHaveLength(4);
+    // current: pageIndex 2 → idx 4, 5 / next: pageIndex 3 → idx 6, 7 / prev: pageIndex 1 → idx 2, 3
+    expect(arg).toHaveLength(6);
+    expect(arg).toContain('thumb-4.webp');
+    expect(arg).toContain('thumb-5.webp');
     expect(arg).toContain('thumb-6.webp');
     expect(arg).toContain('thumb-7.webp');
     expect(arg).toContain('thumb-2.webp');
     expect(arg).toContain('thumb-3.webp');
   });
 
-  it('pageIndex=0이면 음수 인덱스가 필터링되어 2개만 preload한다', () => {
+  it('pageIndex=0이면 음수 인덱스가 필터링되어 4개만 preload한다', () => {
     preloadContentImages(0);
     const arg = vi.mocked(preloadImages).mock.calls[0][0];
-    // pageIndex 1 → idx 2, 3 (kept) / pageIndex -1 → idx -2, -1 (filtered)
-    expect(arg).toHaveLength(2);
+    // current: idx 0, 1 (kept) / next: pageIndex 1 → idx 2, 3 (kept) / prev: pageIndex -1 → idx -2, -1 (filtered)
+    expect(arg).toHaveLength(4);
+    expect(arg).toContain('thumb-0.webp');
+    expect(arg).toContain('thumb-1.webp');
     expect(arg).toContain('thumb-2.webp');
     expect(arg).toContain('thumb-3.webp');
   });
@@ -73,8 +77,10 @@ describe('preloadContentImages', () => {
   it('artworks 범위를 초과하는 인덱스는 필터링된다 (artworks.length=10)', () => {
     preloadContentImages(4);
     const arg = vi.mocked(preloadImages).mock.calls[0][0];
-    // pageIndex 5 → idx 10, 11 (filtered, >= 10) / pageIndex 3 → idx 6, 7 (kept)
-    expect(arg).toHaveLength(2);
+    // current: pageIndex 4 → idx 8, 9 (kept) / next: pageIndex 5 → idx 10, 11 (filtered) / prev: pageIndex 3 → idx 6, 7 (kept)
+    expect(arg).toHaveLength(4);
+    expect(arg).toContain('thumb-8.webp');
+    expect(arg).toContain('thumb-9.webp');
     expect(arg).toContain('thumb-6.webp');
     expect(arg).toContain('thumb-7.webp');
   });

--- a/src/features/history/model/helpers.ts
+++ b/src/features/history/model/helpers.ts
@@ -10,7 +10,9 @@ export function getArtworkIndex(pageIndex: number, side: PageSide): number {
 }
 
 export function preloadContentImages(pageIndex: number): void {
-  const adjacentIndices = [
+  const indices = [
+    getArtworkIndex(pageIndex, 'left'),
+    getArtworkIndex(pageIndex, 'right'),
     getArtworkIndex(pageIndex + 1, 'left'),
     getArtworkIndex(pageIndex + 1, 'right'),
     getArtworkIndex(pageIndex - 1, 'left'),
@@ -18,7 +20,7 @@ export function preloadContentImages(pageIndex: number): void {
   ];
 
   preloadImages(
-    adjacentIndices
+    indices
       .filter((idx) => idx >= 0 && idx < artworks.length)
       .map((idx) => getThumbnailImage(idx)),
   );

--- a/src/widgets/award/ui/Popup.tsx
+++ b/src/widgets/award/ui/Popup.tsx
@@ -16,11 +16,7 @@ export function AwardPopup() {
       ariaLabel={`${title} 수상 이미지`}
       onClose={() => setSelectedId(null)}
     >
-      <img
-        src={getAwardImage(selectedId)}
-        alt={`${title} 수상 이미지`}
-        loading='lazy'
-      />
+      <img src={getAwardImage(selectedId)} alt={`${title} 수상 이미지`} />
     </Popup>
   );
 }

--- a/src/widgets/history/ui/History.tsx
+++ b/src/widgets/history/ui/History.tsx
@@ -1,7 +1,11 @@
 import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 
-import { PAGE_SIDE, RAPID_FLIP_DURATION } from '@features/history';
+import {
+  PAGE_SIDE,
+  preloadContentImages,
+  RAPID_FLIP_DURATION,
+} from '@features/history';
 import type { IndexItem } from '@features/history';
 import { useBookCoverState } from '@features/history';
 import { useBookNavigation } from '@features/history';
@@ -114,7 +118,9 @@ export function History() {
   }, [bookState, pendingCategory]);
 
   function handleListItemClick(index: number) {
-    navigateToCategory('Content', Math.floor(index / 2), true);
+    const pageIndex = Math.floor(index / 2);
+    preloadContentImages(pageIndex);
+    navigateToCategory('Content', pageIndex, true);
   }
 
   function page(
@@ -218,6 +224,7 @@ export function History() {
 
   function handleNavigateToCategory(item: IndexItem) {
     trackHistoryCategoryChange(String(item));
+    if (item === 'Content') preloadContentImages(0);
     if (bookState === 'cover-front') {
       if (isAnimatingRef.current) return;
       setPendingCategory(item);

--- a/src/widgets/history/ui/book/content_container/Content.tsx
+++ b/src/widgets/history/ui/book/content_container/Content.tsx
@@ -183,7 +183,7 @@ function ContentItem({
         >
           {imageSrc && (
             <>
-              <img src={imageSrc} alt={item.title} loading='lazy' />
+              <img src={imageSrc} alt={item.title} />
               <div className='content__image-zoom' aria-hidden='true'>
                 <MdOutlineZoomOutMap />
               </div>

--- a/src/widgets/patent/ui/Popup.tsx
+++ b/src/widgets/patent/ui/Popup.tsx
@@ -15,7 +15,6 @@ export function PatentPopup({
       <img
         src={getPatentImage(patentId)}
         alt={`${patentTitle} 특허증 이미지`}
-        loading='lazy'
       />
     </Popup>
   );


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

관련 이슈 없음

### 팝업·컨텐츠 이미지 lazy 로딩 제거

팝업(수상, 특허)과 History Content 이미지에 `loading="lazy"`가 적용되어 있어, 팝업을 열거나 컨텐츠 페이지에 진입할 때 이미지가 즉시 표시되지 않는 UX 문제가 있었습니다.
팝업·컨텐츠처럼 즉각 노출이 필요한 요소에는 lazy 로딩이 적절하지 않으므로 제거하고, 대신 프리로드 범위를 현재 페이지까지 확장하여 이미지가 미리 준비되도록 개선했습니다.

### 핵심 변화

#### 변경 전

- `AwardPopup`, `PatentPopup`, `Content` 이미지에 `loading="lazy"` 적용
- `preloadContentImages`: 인접 페이지(±1) 이미지 4개만 프리로드

#### 변경 후

- 팝업·컨텐츠 이미지에서 `loading="lazy"` 제거
- `preloadContentImages`: 현재 페이지 포함 최대 6개 프리로드
- History 리스트 아이템 클릭 및 Content 카테고리 진입 시 프리로드 즉시 호출

# 📋 작업 내용

- `src/widgets/award/ui/Popup.tsx`: `loading="lazy"` 제거
- `src/widgets/patent/ui/Popup.tsx`: `loading="lazy"` 제거
- `src/widgets/history/ui/book/content_container/Content.tsx`: `loading="lazy"` 제거
- `src/features/history/model/helpers.ts`: 프리로드 대상에 현재 페이지 이미지 추가
- `src/widgets/history/ui/History.tsx`: 리스트 클릭·카테고리 진입 시 프리로드 호출 추가
- `src/features/history/model/helpers.test.ts`: 변경된 프리로드 범위에 맞춰 테스트 수정

# 📷 스크린 샷 (선택 사항)

동작 화면 첨부