### PR TITLE
👹 fix: 모바일 팝업 오픈 시 배경 스크롤(스와이프) 방지

### DIFF
--- a/src/shared/ui/Popup/model/usePopup.ts
+++ b/src/shared/ui/Popup/model/usePopup.ts
@@ -97,10 +97,26 @@ export function usePopup(
       }
     };
 
+    const handleTouchMove = (e: TouchEvent) => {
+      let el = e.target instanceof Element ? e.target : null;
+      while (el && dialogRef.current?.contains(el)) {
+        const { overflowY } = getComputedStyle(el);
+        if (
+          (overflowY === 'scroll' || overflowY === 'auto') &&
+          el.scrollHeight > el.clientHeight
+        ) {
+          return;
+        }
+        el = el.parentElement;
+      }
+      e.preventDefault();
+    };
+
     const handlePopState = () => onCloseRef.current();
 
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('wheel', handleWheel, { passive: false });
+    window.addEventListener('touchmove', handleTouchMove, { passive: false });
     window.addEventListener('popstate', handlePopState);
 
     return () => {
@@ -113,6 +129,7 @@ export function usePopup(
 
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('wheel', handleWheel);
+      window.removeEventListener('touchmove', handleTouchMove);
       window.removeEventListener('popstate', handlePopState);
 
       queueMicrotask(() =>


### PR DESCRIPTION
# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

관련 이슈 없음

### 문제 상황

팝업이 열린 상태에서 모바일에서 팝업 테두리 위치에서 스와이프 할 경우 배경이 움직이는 문제 발생

### 핵심 변화

#### 변경 전

- 팝업 외부 영역에 대한 `wheel` / `touchmove` 이벤트를 차단하지 않음
- 팝업 열림 중 키보드 방향키(`ArrowUp`, `PageDown` 등)로 배경 스크롤 가능

#### 변경 후

- `handleWheel`: 팝업 외부에서 발생하는 휠 이벤트를 `passive: false`로 등록 후 `preventDefault()`
- `handleTouchMove`: 팝업 외부 터치 이동 차단. 단, 팝업 내부에서 `overflow: scroll/auto`이고 실제 스크롤 가능한 요소는 허용(내부 스크롤 보존)
- `SCROLL_KEYS`: 팝업 외부에 포커스가 있을 때 키보드 스크롤 키 차단

# 📋 작업 내용

- `src/shared/ui/Popup/model/usePopup.ts`
  - `SCROLL_KEYS` Set 추가 (방향키 / PageUp·Down / Home·End)
  - `handleWheel` 이벤트 핸들러 추가 → 팝업 외부 휠 스크롤 차단
  - `handleTouchMove` 이벤트 핸들러 추가 → 팝업 외부 터치 스크롤 차단 (내부 스크롤 가능 요소는 통과)
  - 두 이벤트 모두 `{ passive: false }` 옵션으로 등록하여 `preventDefault()` 동작 보장