### PR TITLE
✨ feat: 404 Not Found 페이지 구현

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
 import { Home } from '@pages/home';
+import { NotFound } from '@pages/not-found';
 import { PrivacyPolicy } from '@pages/privacy-policy';
 import { trackBrowserLimited, useGoogleAnalytics } from '@shared/lib/analytics';
 import { getBrowserSupport } from '@shared/lib/browserCompat';
@@ -17,6 +18,7 @@ function App() {
     <Routes>
       <Route path='/' element={<Home />} />
       <Route path='/privacy_policy' element={<PrivacyPolicy />} />
+      <Route path='*' element={<NotFound />} />
     </Routes>
   );
 }

--- a/src/pages/not-found/NotFound.stories.tsx
+++ b/src/pages/not-found/NotFound.stories.tsx
@@ -1,0 +1,40 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { NotFound } from './NotFound';
+
+const meta = {
+  title: 'Pages/NotFound',
+  component: NotFound,
+  decorators: [
+    (Story) => (
+      <MemoryRouter initialEntries={['/unknown']}>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          '404 Not Found 페이지. 존재하지 않는 경로 접근 시 렌더링되며, 홈으로 돌아가기 버튼을 포함한다.',
+      },
+    },
+  },
+} satisfies Meta<typeof NotFound>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '기본',
+  parameters: {
+    docs: {
+      description: {
+        story: '미매칭 경로 접근 시 표시되는 404 전체 페이지 레이아웃.',
+      },
+    },
+  },
+};

--- a/src/pages/not-found/NotFound.test.tsx
+++ b/src/pages/not-found/NotFound.test.tsx
@@ -1,0 +1,81 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NotFound } from './NotFound';
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <NotFound />
+    </MemoryRouter>,
+  );
+}
+
+describe('NotFound', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('시맨틱 구조', () => {
+    it('최상위 요소에 not-found 클래스가 있다', () => {
+      const { container } = renderPage();
+      expect(container.querySelector('.not-found')).toBeInTheDocument();
+    });
+
+    it('404 코드가 표시된다', () => {
+      renderPage();
+      expect(screen.getByText('404')).toBeInTheDocument();
+    });
+
+    it('h1 제목 "페이지를 찾을 수 없습니다"가 렌더링된다', () => {
+      renderPage();
+      expect(
+        screen.getByRole('heading', {
+          level: 1,
+          name: '페이지를 찾을 수 없습니다',
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it('안내 문구가 표시된다', () => {
+      renderPage();
+      expect(
+        screen.getByText('요청하신 페이지가 존재하지 않거나 이동되었습니다.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('홈으로 돌아가기 버튼', () => {
+    it('버튼이 렌더링된다', () => {
+      renderPage();
+      expect(
+        screen.getByRole('button', { name: '홈으로 돌아가기' }),
+      ).toBeInTheDocument();
+    });
+
+    it('버튼 클릭 시 "/"로 navigate한다', async () => {
+      renderPage();
+      await userEvent.click(
+        screen.getByRole('button', { name: '홈으로 돌아가기' }),
+      );
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+
+    it('버튼 클릭 시 navigate가 정확히 1번 호출된다', async () => {
+      renderPage();
+      await userEvent.click(
+        screen.getByRole('button', { name: '홈으로 돌아가기' }),
+      );
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/pages/not-found/NotFound.tsx
+++ b/src/pages/not-found/NotFound.tsx
@@ -1,0 +1,22 @@
+import { useNavigate } from 'react-router-dom';
+
+import './styles/NotFound.css';
+
+export function NotFound() {
+  const navigate = useNavigate();
+
+  return (
+    <div className='not-found'>
+      <div className='not-found__content'>
+        <p className='not-found__code'>404</p>
+        <h1 className='not-found__title'>페이지를 찾을 수 없습니다</h1>
+        <p className='not-found__desc'>
+          요청하신 페이지가 존재하지 않거나 이동되었습니다.
+        </p>
+        <button className='not-found__btn' onClick={() => void navigate('/')}>
+          홈으로 돌아가기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/not-found/index.ts
+++ b/src/pages/not-found/index.ts
@@ -1,0 +1,1 @@
+export { NotFound } from './NotFound';

--- a/src/pages/not-found/styles/NotFound.css
+++ b/src/pages/not-found/styles/NotFound.css
@@ -1,0 +1,79 @@
+.not-found {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100dvh;
+  background-color: var(--brown-900);
+  padding: 2rem;
+}
+
+.not-found__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.25rem;
+}
+
+.not-found__code {
+  font-size: max(96px, 8.33vw);
+  font-weight: 900;
+  line-height: 1;
+  letter-spacing: -0.05em;
+  color: var(--accent-gold-400);
+  user-select: none;
+}
+
+.not-found__title {
+  font-size: max(20px, 1.667vw);
+  font-weight: 700;
+  color: var(--white);
+  letter-spacing: -0.03em;
+}
+
+.not-found__desc {
+  font-size: max(13px, 0.938vw);
+  font-weight: 400;
+  color: var(--brown-300);
+  line-height: 1.6;
+}
+
+.not-found__btn {
+  margin-top: 0.5rem;
+  padding: 0.75rem 2.25rem;
+  background-color: var(--accent-gold-400);
+  color: var(--brown-900);
+  font-size: max(13px, 0.938vw);
+  font-weight: 700;
+  border-radius: 0.25rem;
+  letter-spacing: -0.02em;
+  transition:
+    background-color 0.2s ease,
+    transform 0.15s ease;
+}
+
+.not-found__btn:hover {
+  background-color: var(--accent-gold-600);
+  transform: translateY(-2px);
+}
+
+@media (max-width: 767px) {
+  .not-found__code {
+    font-size: clamp(72px, 20vw, 120px);
+  }
+
+  .not-found__title {
+    font-size: clamp(18px, 5vw, 28px);
+  }
+
+  .not-found__desc {
+    font-size: clamp(12px, 3.73vw, 16px);
+  }
+
+  .not-found__btn {
+    font-size: clamp(13px, 3.73vw, 16px);
+    padding: 0.875rem 2rem;
+    width: 100%;
+    max-width: 280px;
+  }
+}


### PR DESCRIPTION
<!--
```
- PR이 승인되면 해당 브랜치 삭제하기
```
-->

# 💫 테스크

### PR CHECK LIST

- [x] commit 메세지가 적절한지 확인하기
- [x] 적절한 브랜치로 요청했는지 확인하기

### Issue

관련 이슈 없음

### 404 페이지 구현

- 존재하지 않는 경로 접근 시 사용자에게 명확한 피드백 제공 필요
- `react-router-dom` wildcard route(`*`)를 활용해 모든 미매칭 경로를 처리

### 핵심 변화

#### 변경 전

- 존재하지 않는 URL 접근 시 빈 화면 또는 홈 화면으로 처리

#### 변경 후

- 404 코드, 안내 문구, 홈으로 돌아가기 버튼이 있는 전용 페이지 렌더링

# 📋 작업 내용

- `src/pages/not-found/NotFound.tsx` — 404 페이지 컴포넌트 구현
- `src/pages/not-found/styles/NotFound.css` — 404 페이지 스타일링
- `src/pages/not-found/index.ts` — FSD public API 노출
- `src/app/App.tsx` — wildcard route(`*`)에 `NotFound` 컴포넌트 연결

# 📷 스크린 샷 (선택 사항)

동작 화면 첨부